### PR TITLE
Limits

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,20 +6,48 @@ import Documentation from './Documentation';
 import Transforms from './inputs/Transforms';
 import MachinePreview from './MachinePreview';
 import GCodeGenerator from './GCode';
+import enforceLimits from './LimitEnforcer';
 
 class App extends Component {
-
   constructor(props) {
     super(props)
     this.state = {
       vertices: [
       ],
-    };
+      min_x: 0.0,
+      max_x: 500.0,
+      min_y: 0.0,
+      max_y: 500.0,
+    }
+    this.onMinXChange = this.onMinXChange.bind(this)
+    this.onMaxXChange = this.onMaxXChange.bind(this)
+    this.onMinYChange = this.onMinYChange.bind(this)
+    this.onMaxYChange = this.onMaxYChange.bind(this)
 
     this.setVertices = this.setVertices.bind(this);
   }
 
+  onMinXChange(event) {
+    this.setState({ min_x: event.target.value })
+  }
+
+  onMaxXChange(event) {
+    this.setState({ max_x: event.target.value })
+  }
+
+  onMinYChange(event) {
+    this.setState({ min_y: event.target.value })
+  }
+
+  onMaxYChange(event) {
+    this.setState({ max_y: event.target.value })
+  }
+
   setVertices(vertices) {
+    vertices = enforceLimits(vertices,
+                             (this.state.max_x - this.state.min_x)/2.0,
+                             (this.state.max_y - this.state.min_y)/2.0
+                             );
     this.setState({ vertices: vertices });
   }
 
@@ -42,7 +70,19 @@ class App extends Component {
 
         <div className="App-right">
           <div className="App-canvas">
-            <MachinePreview canvas_width={600} canvas_height={600} vertices={this.state.vertices}/>
+            <MachinePreview
+              canvas_width={600}
+              canvas_height={600}
+              min_x={this.state.min_x}
+              max_x={this.state.max_x}
+              min_y={this.state.min_y}
+              max_y={this.state.max_y}
+              onMinXChange={this.onMinXChange}
+              onMaxXChange={this.onMaxXChange}
+              onMinYChange={this.onMinYChange}
+              onMaxYChange={this.onMaxYChange}
+              vertices={this.state.vertices}
+              />
           </div>
 
           <div id="output">

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,6 @@ import Documentation from './Documentation';
 import Transforms from './inputs/Transforms';
 import MachinePreview from './MachinePreview';
 import GCodeGenerator from './GCode';
-import Vertex from './Geometry';
 
 class App extends Component {
 
@@ -14,8 +13,6 @@ class App extends Component {
     super(props)
     this.state = {
       vertices: [
-        Vertex(0.0, 0.0),
-        Vertex(1.0, 1.0),
       ],
     };
 

--- a/src/LimitEnforcer.js
+++ b/src/LimitEnforcer.js
@@ -1,0 +1,111 @@
+
+import Vertex from './Geometry';
+
+// Finds the nearest vertex that is in the bounds.
+function nearestVertex(vertex, size_x, size_y) {
+  return Vertex(Math.min(size_x, Math.max(-size_x, vertex.x)),
+                Math.min(size_y, Math.max(-size_y, vertex.y)));
+}
+
+// Find the point on the line defined by these two vertices that is exactly within the limits.
+function boundPoint(good, bad, size_x, size_y) {
+  var dx = good.x - bad.x;
+  var dy = good.y - bad.y;
+
+  var fixed = Vertex(bad.x, bad.y);
+  var distance = 0;
+  if (bad.x < -size_x || bad.x > size_x) {
+    if (bad.x < -size_x) {
+      // we are leaving the left
+      fixed.x = -size_x;
+    } else {
+      // we are leaving the right
+      fixed.x = size_x;
+    }
+    distance = (fixed.x - good.x) / dx;
+    fixed.y = good.y + distance * dy;
+    // We fixed x, but y might have the same problem, so we'll rerun this, with different points.
+    return boundPoint(good, fixed, size_x, size_y);
+  }
+  if (bad.y < -size_y || bad.y > size_y) {
+    if (bad.y < -size_y) {
+      // we are leaving the bottom
+      fixed.y = -size_y;
+    } else {
+      // we are leaving the top
+      fixed.y = size_y;
+    }
+    distance = (fixed.y - good.y) / dy;
+    fixed.x = good.x + distance * dx;
+  }
+  return fixed;
+}
+
+// Tries to abuse the design as little as possible, but guarantees the points will all be within the
+// limits of the machine. The limits are [-size_x,size_x],[-size_y,size_y]
+//
+// The basic idea of this algorithm is:
+//   - Is the point out of bounds (oob)?
+//     - Yes, then:
+//       - Find the point along the line that intersects with the boundary (boundPoint). Add in that
+//       point
+//       - If the oob point is exiting at a corner, then insert the corner point.
+//       - Next loop, find the point along the next line that comes from the oob point to the next
+//       point. Add in that point.
+//     - No, then:
+//       - Keep that point.
+//   - After preserving the shape as much as possible with the above, there are still some strange
+//   cases where it will fail, like if the line segment is from oob left to oob right, so just clip
+//   those to the nearestPoint.
+function enforceLimits(vertices, size_x, size_y) {
+  var cleanVertices = []
+  var previous = null;
+  var previous_oob = false;
+  for (var next=0; next<vertices.length; next++) {
+    var vertex = vertices[next];
+
+    // If there was a previous OOB point, then find the point that intersects with the limit.
+      // What if there are two limits? We might need some way to bail? Maybe just find the nearest
+      // this time.
+    // Determine if the vertex is OOB.
+    // If it is, then calculate the mx+b
+      // calculate the intersect with the limit
+      // calculate the "nearest" point
+      // cache the desired point, so that next time, it can be extended.
+      //
+    if (previous) {
+      if (previous_oob) {
+        cleanVertices.push(boundPoint(vertex, previous, size_x, size_y));
+        previous_oob = false;
+      }
+
+      if (vertex.x < -size_x || vertex.x > size_x ||
+          vertex.y < -size_y || vertex.y > size_y) {
+        // save the vertex along the line towards the border.
+        cleanVertices.push(boundPoint(previous, vertex, size_x, size_y));
+        previous_oob = true;
+        // Insert another point at the corners, if we have exited out the corners.
+        if ((vertex.x < -size_x || vertex.x > size_x) &&
+            (vertex.y < -size_y || vertex.y > size_y)) {
+          cleanVertices.push(nearestVertex(vertex, size_x, size_y));
+        }
+
+      } else {
+        cleanVertices.push(vertex);
+      }
+    } else {
+      cleanVertices.push(vertex);
+    }
+    previous = vertex;
+  }
+
+  // Just for sanity, and cases that I haven't thought of, clean this list again.
+  var cleanerVertices = []
+  for (var i=0; i<cleanVertices.length; i++) {
+    cleanerVertices.push(nearestVertex(cleanVertices[i], size_x, size_y));
+  }
+
+  return cleanerVertices;
+}
+
+export default enforceLimits

--- a/src/LimitEnforcer.js
+++ b/src/LimitEnforcer.js
@@ -7,6 +7,12 @@ function nearestVertex(vertex, size_x, size_y) {
                 Math.min(size_y, Math.max(-size_y, vertex.y)));
 }
 
+// Determines of a point is in bounds or out.
+function outOfBounds(vertex, size_x, size_y) {
+  return (vertex.x < -size_x || vertex.x > size_x ||
+          vertex.y < -size_y || vertex.y > size_y);
+}
+
 // Find the point on the line defined by these two vertices that is exactly within the limits.
 function boundPoint(good, bad, size_x, size_y) {
   var dx = good.x - bad.x;
@@ -75,12 +81,16 @@ function enforceLimits(vertices, size_x, size_y) {
       //
     if (previous) {
       if (previous_oob) {
-        cleanVertices.push(boundPoint(vertex, previous, size_x, size_y));
-        previous_oob = false;
+        if (outOfBounds(vertex)) {
+          // both previous and this point are out of bounds, don't try to find the boundPoint.
+          cleanVertices.push(nearestVertex(previous, size_x, size_y));
+        } else {
+          // We are coming back into frame. Insert a point on the border.
+          cleanVertices.push(boundPoint(vertex, previous, size_x, size_y));
+        }
       }
 
-      if (vertex.x < -size_x || vertex.x > size_x ||
-          vertex.y < -size_y || vertex.y > size_y) {
+      if (outOfBounds(vertex)) {
         // save the vertex along the line towards the border.
         cleanVertices.push(boundPoint(previous, vertex, size_x, size_y));
         previous_oob = true;
@@ -89,9 +99,9 @@ function enforceLimits(vertices, size_x, size_y) {
             (vertex.y < -size_y || vertex.y > size_y)) {
           cleanVertices.push(nearestVertex(vertex, size_x, size_y));
         }
-
       } else {
         cleanVertices.push(vertex);
+        previous_oob = false;
       }
     } else {
       cleanVertices.push(vertex);

--- a/src/MachinePreview.js
+++ b/src/MachinePreview.js
@@ -144,54 +144,24 @@ class MachineSettings extends Component {
 }
 
 class MachinePreview extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      min_x: 0.0,
-      max_x: 500.0,
-      min_y: 0.0,
-      max_y: 500.0,
-    }
-    this.onMinXChange = this.onMinXChange.bind(this)
-    this.onMaxXChange = this.onMaxXChange.bind(this)
-    this.onMinYChange = this.onMinYChange.bind(this)
-    this.onMaxYChange = this.onMaxYChange.bind(this)
-  }
-
-  onMinXChange(event) {
-    this.setState({ min_x: event.target.value })
-  }
-
-  onMaxXChange(event) {
-    this.setState({ max_x: event.target.value })
-  }
-
-  onMinYChange(event) {
-    this.setState({ min_y: event.target.value })
-  }
-
-  onMaxYChange(event) {
-    this.setState({ max_y: event.target.value })
-  }
-
   render() {
     return (
       <div className="machine-preview">
         <MachineSettings
-          min_x={this.state.min_x}
-          max_x={this.state.max_x}
-          min_y={this.state.min_y}
-          max_y={this.state.max_y}
-          onMinXChange={this.onMinXChange}
-          onMaxXChange={this.onMaxXChange}
-          onMinYChange={this.onMinYChange}
-          onMaxYChange={this.onMaxYChange}
+          min_x={this.props.min_x}
+          max_x={this.props.max_x}
+          min_y={this.props.min_y}
+          max_y={this.props.max_y}
+          onMinXChange={this.props.onMinXChange}
+          onMaxXChange={this.props.onMaxXChange}
+          onMinYChange={this.props.onMinYChange}
+          onMaxYChange={this.props.onMaxYChange}
           />
         <PreviewWindow
-          min_x={this.state.min_x}
-          max_x={this.state.max_x}
-          min_y={this.state.min_y}
-          max_y={this.state.max_y}
+          min_x={this.props.min_x}
+          max_x={this.props.max_x}
+          min_y={this.props.min_y}
+          max_y={this.props.max_y}
           canvas_width={this.props.canvas_width}
           canvas_height={this.props.canvas_height}
           vertices={this.props.vertices}


### PR DESCRIPTION
Limit vertices to stay inside the machine limits, but don't change the shape (when possible). 

I know this still has at least two issues:
 - When the limits change after the vertices, it's not updating the vertcies. I think there must be a simple way to fix this, but I'm not familiar with it.
 - When two consecutive points are out of bounds, like an entire side of a square, it's doing something funny, where it goes across the entire border. Needs some investigation.