### PR TITLE
option to draw multiple loops within a track; option to apply transfo…

### DIFF
--- a/src/common/Computer.js
+++ b/src/common/Computer.js
@@ -79,7 +79,7 @@ const getShapeVertices = (state) => {
     return scale(vertex, 100.0 * state.shape.startingSize)
   })
 
-  if (state.transform.transformFrequency === 'point' && state.transform.repeatEnabled) {
+  if (state.transform.transformMethod === 'smear' && state.transform.repeatEnabled) {
     // remove last vertex; we don't want to return to our starting point when completing the shape
     vertices.pop()
   }
@@ -197,7 +197,7 @@ function buildTrackLoop(state, i, t) {
   let trackDistances = []
 
   for (var j=0; j<numVertices; j++) {
-    const amount = state.transform.transformFrequency === 'point' ? i + t + j/input.length : i + t
+    const amount = state.transform.transformMethod === 'smear' ? i + t + j/input.length : i + t
     const trackVertex = transform(state.transform, input[j], amount, i, numTrackLoops)
     trackVertices.push(trackVertex)
 
@@ -290,7 +290,7 @@ export const transformShapes = (state) => {
     } else {
       for (i=0; i<numLoops; i++) {
         for (var j=0; j<input.length; j++) {
-          let amount = state.transform.transformFrequency === 'point' ? i + j/input.length : i
+          let amount = state.transform.transformMethod === 'smear' ? i + j/input.length : i
           outputVertices.push(transform(state.transform, input[j], amount, amount))
         }
       }

--- a/src/common/Computer.js
+++ b/src/common/Computer.js
@@ -277,7 +277,7 @@ export const transformShapes = (state) => {
   let outputVertices = []
 
   for (var i=0; i<numLoops; i++) {
-    if (numTrackLoops > 1) {
+    if (state.transform.trackEnabled && numTrackLoops > 1) {
       for (var t=0; t<numTrackLoops; t++) {
         outputVertices = outputVertices.concat(buildTrackLoop(state, i, t))
       }

--- a/src/common/Computer.js
+++ b/src/common/Computer.js
@@ -75,9 +75,15 @@ export const transform = (data, vertex, amount, trackIndex=0, numLoops) => {
 // Vertex functions
 const getShapeVertices = (state) => {
   const shape = getShape(state.shape)
-  return shape.getVertices(state).map(vertex => {
+  let vertices = shape.getVertices(state).map(vertex => {
     return scale(vertex, 100.0 * state.shape.startingSize)
   })
+
+  if (state.transform.transformFrequency === 'point' && state.transform.repeatEnabled) {
+    // remove last vertex; we don't want to return to our starting point when completing the shape
+    vertices.pop()
+  }
+  return vertices
 }
 
 function addRectEndpoints(machine, vertices) {

--- a/src/common/Geometry.js
+++ b/src/common/Geometry.js
@@ -1,6 +1,5 @@
 // A simple struct that we can use everywhere we need vertices. I don't see a
 // problem letting this bloat a little.
-//
 export const Vertex = (x, y, speed=0) => {
   return {
     x: x,
@@ -17,4 +16,8 @@ export const degToRad = (deg) => {
 // convert radians to degrees
 export const radToDeg = (rad) => {
   return rad * 180.0 / Math.PI
+}
+
+export const distance = (v1, v2) => {
+  return Math.sqrt(Math.pow(v1.x - v2.x, 2.0) + Math.pow(v1.y - v2.y, 2.0))
 }

--- a/src/features/app/store.js
+++ b/src/features/app/store.js
@@ -35,7 +35,7 @@ Object.keys(registeredShapes).forEach(key => {
 
 // set to true when running locally if you want to preserve your shape
 // settings across page loads; don't forget to toggle false when done testing!
-const persistState = false
+const persistState = true
 if (persistState) {
   // override default values with saved ones
   const persistedState = loadState()

--- a/src/features/app/store.js
+++ b/src/features/app/store.js
@@ -35,7 +35,7 @@ Object.keys(registeredShapes).forEach(key => {
 
 // set to true when running locally if you want to preserve your shape
 // settings across page loads; don't forget to toggle false when done testing!
-const persistState = true
+const persistState = false
 if (persistState) {
   // override default values with saved ones
   const persistedState = loadState()

--- a/src/features/gcode/selectors.js
+++ b/src/features/gcode/selectors.js
@@ -63,23 +63,28 @@ export const getComments = createSelector(
           comments.push("      " + shapeOptions[key].title + ": " + shape[key])
         })
 
-        comments.push("    Number of Loops: " + state.transform.numLoops)
-        comments.push("    Spin: " + state.transform.spinEnabled)
-        if (state.transform.spinEnabled) {
-          comments.push("      Spin Value: " + state.transform.spinValue)
-          comments.push("      Spin Switchbacks: " + state.transform.spinSwitchbacks)
-        }
-        comments.push("    Grow: " + state.transform.growEnabled)
-        if (state.transform.growEnabled) {
-          comments.push("      Grow Value: " + state.transform.growValue)
-        }
-        comments.push("    Track: " + state.transform.trackEnabled)
-        if (state.transform.trackEnabled) {
-          comments.push("      Track Size: " + state.transform.trackValue)
-          comments.push("      Track Length: " + state.transform.trackLength)
-          comments.push("      Track Grow: " + state.transform.trackGrowEnabled)
-          if (state.transform.trackGrowEnabled) {
-            comments.push("          Track Grow Value: " + state.transform.trackGrow)
+        if (state.transform.repeatEnabled) {
+          comments.push("    Number of Loops: " + state.transform.numLoops)
+          comments.push("    Transform Method: " + state.transform.transformMethod)
+          comments.push("    Spin: " + state.transform.spinEnabled)
+          if (state.transform.spinEnabled) {
+            comments.push("      Spin Value: " + state.transform.spinValue)
+            comments.push("      Spin Switchbacks: " + state.transform.spinSwitchbacks)
+          }
+          comments.push("    Grow: " + state.transform.growEnabled)
+          if (state.transform.growEnabled) {
+            comments.push("      Grow Value: " + state.transform.growValue)
+          }
+          comments.push("    Track: " + state.transform.trackEnabled)
+          if (state.transform.trackEnabled) {
+            comments.push("      Track Size: " + state.transform.trackValue)
+            comments.push("      Track Length: " + state.transform.trackLength)
+            comments.push("      Track Number of Loops: " + state.transform.trackNumLoops)
+            comments.push("      Track Grow: " + state.transform.trackGrowEnabled)
+
+            if (state.transform.trackGrowEnabled) {
+              comments.push("          Track Grow Value: " + state.transform.trackGrow)
+            }
           }
         }
         break

--- a/src/features/machine/PreviewWindow.js
+++ b/src/features/machine/PreviewWindow.js
@@ -24,7 +24,7 @@ const getTrackVertices = createSelector(
     var trackVertices = []
     for (var i=0; i<numLoops; i++) {
       if (currentTransform.trackEnabled) {
-        trackVertices.push(transform(currentTransform, {x: 0.0, y: 0.0}, i))
+        trackVertices.push(transform(currentTransform, {x: 0.0, y: 0.0}, i, i))
       }
     }
     return trackVertices

--- a/src/features/machine/PreviewWindow.js
+++ b/src/features/machine/PreviewWindow.js
@@ -142,7 +142,7 @@ class PreviewWindow extends Component {
 
     // never return less than two vertices; this keeps the preview slider smooth even when
     // there are just a few vertices
-    if (begin_vertex == end_vertex) {
+    if (begin_vertex === end_vertex) {
       if (begin_vertex > 1) begin_vertex = begin_vertex - 2
     } else if (begin_vertex === end_vertex - 1) {
       if (begin_vertex > 0) begin_vertex = begin_vertex - 1

--- a/src/features/transforms/TrackTransform.js
+++ b/src/features/transforms/TrackTransform.js
@@ -75,6 +75,14 @@ class TrackTransform extends Component {
                 step={0.05}
                 model={this.props.transform} />
 
+              <InputOption
+                onChange={this.props.onChange}
+                options={this.props.options}
+                key="trackNumLoops"
+                optionKey="trackNumLoops"
+                index={0}
+                model={this.props.transform} />
+
               <Accordion defaultActiveKey={activeGrowKey} className="mt-3">
                 <Card className={activeGrowClassName}>
                   <Accordion.Toggle as={Card.Header} eventKey={0} onClick={this.props.onTrackGrow}>

--- a/src/features/transforms/Transforms.js
+++ b/src/features/transforms/Transforms.js
@@ -2,7 +2,12 @@ import { connect } from 'react-redux'
 import React, { Component } from 'react'
 import {
   Accordion,
-  Card
+  Card,
+  Row,
+  Col,
+  Form,
+  ToggleButton,
+  ToggleButtonGroup
 } from 'react-bootstrap'
 import InputOption from '../../components/InputOption'
 import DropdownOption from '../../components/DropdownOption'
@@ -37,6 +42,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onRepeat: () => {
       dispatch(toggleRepeat({id: id}))
     },
+    onTransformFrequencyChange: (value) => {
+      dispatch(updateTransform({ transformFrequency: value, id: id}))
+    }
   }
 }
 
@@ -80,13 +88,20 @@ class Transforms extends Component {
                   index={0}
                   model={this.props.transform} />
 
-                  <DropdownOption
-                    onChange={this.props.onChange}
-                    options={this.props.options}
-                    key="transformFrequency"
-                    optionKey="transformFrequency"
-                    index={0}
-                    model={this.props.transform} />
+                  <Row className="align-items-center pb-2">
+                    <Col sm={5}>
+                      <Form.Label htmlFor="transformFrequency">
+                        When transforming shape
+                      </Form.Label>
+                    </Col>
+
+                    <Col sm={7}>
+                      <ToggleButtonGroup id="transformFrequency" type="radio" name="transformFrequency" value={this.props.transform.transformFrequency} onChange={this.props.onTransformFrequencyChange}>
+                        <ToggleButton variant="light" value="point">smear</ToggleButton>
+                        <ToggleButton variant="light" value="loop">keep intact</ToggleButton>
+                      </ToggleButtonGroup>
+                    </Col>
+                  </Row>
 
                   <Accordion className="mt-3">
                     <ScaleTransform id={this.props.transform.id} />

--- a/src/features/transforms/Transforms.js
+++ b/src/features/transforms/Transforms.js
@@ -10,7 +10,6 @@ import {
   ToggleButtonGroup
 } from 'react-bootstrap'
 import InputOption from '../../components/InputOption'
-import DropdownOption from '../../components/DropdownOption'
 import {
   updateTransform,
   toggleRepeat

--- a/src/features/transforms/Transforms.js
+++ b/src/features/transforms/Transforms.js
@@ -5,6 +5,7 @@ import {
   Card
 } from 'react-bootstrap'
 import InputOption from '../../components/InputOption'
+import DropdownOption from '../../components/DropdownOption'
 import {
   updateTransform,
   toggleRepeat
@@ -78,6 +79,14 @@ class Transforms extends Component {
                   optionKey="numLoops"
                   index={0}
                   model={this.props.transform} />
+
+                  <DropdownOption
+                    onChange={this.props.onChange}
+                    options={this.props.options}
+                    key="transformFrequency"
+                    optionKey="transformFrequency"
+                    index={0}
+                    model={this.props.transform} />
 
                   <Accordion className="mt-3">
                     <ScaleTransform id={this.props.transform.id} />

--- a/src/features/transforms/Transforms.js
+++ b/src/features/transforms/Transforms.js
@@ -41,8 +41,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onRepeat: () => {
       dispatch(toggleRepeat({id: id}))
     },
-    onTransformFrequencyChange: (value) => {
-      dispatch(updateTransform({ transformFrequency: value, id: id}))
+    ontransformMethodChange: (value) => {
+      dispatch(updateTransform({ transformMethod: value, id: id}))
     }
   }
 }
@@ -89,15 +89,15 @@ class Transforms extends Component {
 
                   <Row className="align-items-center pb-2">
                     <Col sm={5}>
-                      <Form.Label htmlFor="transformFrequency">
+                      <Form.Label htmlFor="transformMethod">
                         When transforming shape
                       </Form.Label>
                     </Col>
 
                     <Col sm={7}>
-                      <ToggleButtonGroup id="transformFrequency" type="radio" name="transformFrequency" value={this.props.transform.transformFrequency} onChange={this.props.onTransformFrequencyChange}>
-                        <ToggleButton variant="light" value="point">smear</ToggleButton>
-                        <ToggleButton variant="light" value="loop">keep intact</ToggleButton>
+                      <ToggleButtonGroup id="transformMethod" type="radio" name="transformMethod" value={this.props.transform.transformMethod} onChange={this.props.ontransformMethodChange}>
+                        <ToggleButton variant="light" value="smear">smear</ToggleButton>
+                        <ToggleButton variant="light" value="intact">keep intact</ToggleButton>
                       </ToggleButtonGroup>
                     </Col>
                   </Row>

--- a/src/features/transforms/transformsSlice.spec.js
+++ b/src/features/transforms/transformsSlice.spec.js
@@ -44,7 +44,7 @@ describe('transforms reducer', () => {
           trackValue: 10,
           trackLength: 0.2,
           trackNumLoops: 1,
-          transformFrequency: 'point',
+          transformMethod: 'smear',
           trackGrow: 50.0
         }
       },

--- a/src/features/transforms/transformsSlice.spec.js
+++ b/src/features/transforms/transformsSlice.spec.js
@@ -43,6 +43,8 @@ describe('transforms reducer', () => {
           trackGrowEnabled: false,
           trackValue: 10,
           trackLength: 0.2,
+          trackNumLoops: 1,
+          transformFrequency: 'point',
           trackGrow: 50.0
         }
       },

--- a/src/shapes/Circle.js
+++ b/src/shapes/Circle.js
@@ -28,7 +28,7 @@ export default class Circle extends Shape {
 
   getVertices(state) {
     let points = []
-    for (let i=0; i<128; i++) {
+    for (let i=0; i<=128; i++) {
       let angle = Math.PI * 2.0 / 128.0 * i
       points.push(Vertex(Math.cos(angle), Math.sin(state.shape.circleLobes * angle)/state.shape.circleLobes))
     }

--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -28,7 +28,7 @@ export default class Polygon extends Shape {
 
   getVertices(state) {
     let points = []
-    for (let i=0; i<state.shape.polygonSides; i++) {
+    for (let i=0; i<=state.shape.polygonSides; i++) {
       let angle = Math.PI * 2.0 / state.shape.polygonSides * (0.5 + i)
       points.push(Vertex(Math.cos(angle), Math.sin(angle)))
     }

--- a/src/shapes/Star.js
+++ b/src/shapes/Star.js
@@ -34,7 +34,7 @@ export default class Star extends Shape {
 
   getVertices(state) {
     let points = []
-    for (let i=0; i<state.shape.points * 2; i++) {
+    for (let i=0; i<=state.shape.points * 2; i++) {
       let angle = Math.PI * 2.0 / (2.0 * state.shape.points) * i
       let star_scale = 1.0
       if (i % 2 === 0) {

--- a/src/shapes/Transform.js
+++ b/src/shapes/Transform.js
@@ -9,6 +9,11 @@ const transformOptions = {
     title: 'Number of loops',
     min: 1
   },
+  transformFrequency: {
+    title: 'Transform after each',
+    type: 'dropdown',
+    choices: ['point', 'loop'],
+  },
   growValue: {
     title: 'Scale step (+/-)',
   },
@@ -21,6 +26,10 @@ const transformOptions = {
   },
   trackValue: {
     title: 'Track size',
+  },
+  trackNumLoops: {
+    title: 'Number of loops at each track position',
+    min: 1
   },
   trackLength: {
     title: 'Track length',
@@ -37,6 +46,7 @@ export default class Transform {
       offsetX: 0.0,
       offsetY: 0.0,
       numLoops: 10,
+      transformFrequency: 'point',
       repeatEnabled: true,
       growEnabled: true,
       growValue: 100,
@@ -47,6 +57,7 @@ export default class Transform {
       trackGrowEnabled: false,
       trackValue: 10,
       trackLength: 0.2,
+      trackNumLoops: 1,
       trackGrow: 50.0
     }
   }

--- a/src/shapes/Transform.js
+++ b/src/shapes/Transform.js
@@ -9,10 +9,10 @@ const transformOptions = {
     title: 'Number of loops',
     min: 1
   },
-  transformFrequency: {
+  transformMethod: {
     title: 'Transform after each',
     type: 'dropdown',
-    choices: ['point', 'loop'],
+    choices: ['smear', 'intact'],
   },
   growValue: {
     title: 'Scale step (+/-)',
@@ -46,7 +46,7 @@ export default class Transform {
       offsetX: 0.0,
       offsetY: 0.0,
       numLoops: 10,
-      transformFrequency: 'point',
+      transformMethod: 'smear',
       repeatEnabled: true,
       growEnabled: true,
       growValue: 100,


### PR DESCRIPTION
…rms only once per loop

This PR introduces two new transform settings:
- Ability to apply transforms once per loop, instead of once per point. This allows repeated shapes to maintain their "integrity" as they are drawn. This is not obviously always wanted, but it's a cool effect, and some shapes benefit greatly from this - for example, the attached image shows a fractal with numLoops=2, spun. The fractal pattern is perfectly preserved in each loop.

![image](https://user-images.githubusercontent.com/3259145/78665913-8f28b200-78a4-11ea-9df7-cd9301454f4f.png)

- Ability to loop multiple times at each track position. Here's an example:

![image](https://user-images.githubusercontent.com/3259145/78666278-1c6c0680-78a5-11ea-8ace-da26e84c66f0.png)
