### PR TITLE
rotate until the "pattern" is complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.2.5",
     "color": "^3.1.2",
+    "core-js": "^3.6.5",
+    "jest-canvas-mock": "^2.2.0",
     "lodash": "^4.17.15",
     "node-sass": "^4.13.1",
     "rc-slider": "^8.6.3",
@@ -15,7 +17,7 @@
     "react-dom": "^16.13.0",
     "react-ga": "^2.7.0",
     "react-redux": "^7.2.0",
-    "react-scripts": "3.3.1",
+    "react-scripts": "3.4.1",
     "react-select": "^3.0.8",
     "react-switch": "^5.0.1",
     "reduce-reducers": "^1.0.4",
@@ -24,8 +26,8 @@
     "victor": "^1.1.0"
   },
   "devDependencies": {
-    "gh-pages": "^1.0.0",
     "eslint-plugin-flowtype": "^3.13.0",
+    "gh-pages": "^1.0.0",
     "typescript": "^3.7.5"
   },
   "scripts": {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -6,3 +6,13 @@ export const difference = (c1, c2) => {
 export const roundP = (n, p) => {
   return Math.round((n + Number.EPSILON) * Math.pow(10, p)) / Math.pow(10, p)
 }
+
+// https://stackoverflow.com/a/4652513
+export const reduce = (numerator, denominator) => {
+  let gcd = (a,b) => {
+    return b ? gcd(b, a%b) : a;
+  }
+
+  gcd = gcd(numerator, denominator)
+  return [numerator/gcd, denominator/gcd]
+}

--- a/src/features/app/App.test.js
+++ b/src/features/app/App.test.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
+import 'core-js'
 
-it.skip('renders without crashing', () => {
+it('renders without crashing', () => {
   const div = document.createElement('div')
   ReactDOM.render(<App />, div)
 })

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,3 @@
+import 'jest-canvas-mock'
+
+jest.mock('react-ga')

--- a/src/shapes/Epicycloid.js
+++ b/src/shapes/Epicycloid.js
@@ -1,14 +1,17 @@
 import Victor from 'victor'
 import Shape, { shapeOptions } from './Shape'
+import { reduce } from '../common/util'
 
 const options = {
   ...shapeOptions,
   ...{
     epicycloidA: {
-      title: "Large circle radius"
+      title: "Large circle radius",
+      min: 1
     },
     epicycloidB: {
-      title: "Small circle radius"
+      title: "Small circle radius",
+      min: 1
     },
   }
 }
@@ -32,16 +35,24 @@ export default class Epicycloid extends Shape {
 
   getVertices(state) {
     let points = []
-    let a = parseFloat(state.shape.epicycloidA)
-    let b = parseFloat(state.shape.epicycloidB)
+    let a = parseInt(state.shape.epicycloidA)
+    let b = parseInt(state.shape.epicycloidB)
+    let reduced = reduce(a, b)
+    a = reduced[0]
+    b = reduced[1]
     let rotations = Number.isInteger(a/b) ? 1 : b
+    let scale = 1/(a + 2*b)
 
     for (let i=0; i<128*rotations; i++) {
       let angle = Math.PI * 2.0 / 128.0 * i
-      let scale = 0.18
-      points.push(new Victor(scale * (a + b) * Math.cos(angle) - scale * b * Math.cos(((a + b) / b) * angle),
-                         scale * (a + b) * Math.sin(angle) - scale * b * Math.sin(((a + b) / b) * angle)))
+      points.push(
+        new Victor(
+          (a + b) * Math.cos(angle) - b * Math.cos(((a + b) / b) * angle),
+          (a + b) * Math.sin(angle) - b * Math.sin(((a + b) / b) * angle)
+        ).multiply({x: scale, y: scale})
+      )
     }
+
     return points
   }
 

--- a/src/shapes/Epicycloid.js
+++ b/src/shapes/Epicycloid.js
@@ -5,12 +5,10 @@ const options = {
   ...shapeOptions,
   ...{
     epicycloidA: {
-      title: "Large circle radius",
-      step: 0.1,
+      title: "Large circle radius"
     },
     epicycloidB: {
-      title: "Small circle radius",
-      step: 0.1,
+      title: "Small circle radius"
     },
   }
 }
@@ -26,8 +24,8 @@ export default class Epicycloid extends Shape {
       ...super.getInitialState(),
       ...{
         type: 'epicycloid',
-        epicycloidA: 1.0,
-        epicycloidB: .25
+        epicycloidA: 4,
+        epicycloidB: 1
       }
     }
   }
@@ -36,10 +34,11 @@ export default class Epicycloid extends Shape {
     let points = []
     let a = parseFloat(state.shape.epicycloidA)
     let b = parseFloat(state.shape.epicycloidB)
+    let rotations = Number.isInteger(a/b) ? 1 : b
 
-    for (let i=0; i<128; i++) {
+    for (let i=0; i<128*rotations; i++) {
       let angle = Math.PI * 2.0 / 128.0 * i
-      let scale = 0.65
+      let scale = 0.18
       points.push(new Victor(scale * (a + b) * Math.cos(angle) - scale * b * Math.cos(((a + b) / b) * angle),
                          scale * (a + b) * Math.sin(angle) - scale * b * Math.sin(((a + b) / b) * angle)))
     }

--- a/src/shapes/Hypocycloid.js
+++ b/src/shapes/Hypocycloid.js
@@ -1,14 +1,17 @@
 import Victor from 'victor'
 import Shape, { shapeOptions } from './Shape'
+import { reduce } from '../common/util'
 
 const options = {
   ...shapeOptions,
   ...{
     hypocycloidA: {
-      title: 'Large circle radius'
+      title: 'Large circle radius',
+      min: 1
     },
     hypocycloidB: {
-      title: 'Small circle radius'
+      title: 'Small circle radius',
+      min: 1
     },
   }
 }
@@ -32,16 +35,24 @@ export default class Star extends Shape {
 
   getVertices(state) {
     let points = []
-    let a = parseFloat(state.shape.hypocycloidA)
-    let b = parseFloat(state.shape.hypocycloidB)
+    let a = parseInt(state.shape.hypocycloidA)
+    let b = parseInt(state.shape.hypocycloidB)
+    let reduced = reduce(a, b)
+    a = reduced[0]
+    b = reduced[1]
     let rotations = Number.isInteger(a/b) ? 1 : b
+    let scale = b < a ? 1/a : 1/(2*(b - a/2))
 
     for (let i=0; i<128*rotations; i++) {
       let angle = Math.PI * 2.0 / 128.0 * i
-      let scale = 0.18
-      points.push(new Victor(scale * (a - b) * Math.cos(angle) + scale * b * Math.cos(((a - b) / b) * angle),
-                         scale * (a - b) * Math.sin(angle) - scale * b * Math.sin(((a - b) / b) * angle)))
+      points.push(
+        new Victor(
+          (a - b) * Math.cos(angle) + b * Math.cos(((a - b) / b) * angle),
+          (a - b) * Math.sin(angle) - b * Math.sin(((a - b) / b) * angle)
+        ).multiply({x: scale, y: scale})
+      )
     }
+
     return points
   }
 

--- a/src/shapes/Hypocycloid.js
+++ b/src/shapes/Hypocycloid.js
@@ -5,12 +5,10 @@ const options = {
   ...shapeOptions,
   ...{
     hypocycloidA: {
-      title: 'Large circle radius',
-      step: 0.1,
+      title: 'Large circle radius'
     },
     hypocycloidB: {
-      title: 'Small circle radius',
-      step: 0.1,
+      title: 'Small circle radius'
     },
   }
 }
@@ -26,8 +24,8 @@ export default class Star extends Shape {
       ...super.getInitialState(),
       ...{
         type: 'hypocycloid',
-        hypocycloidA: 1.5,
-        hypocycloidB: 0.25
+        hypocycloidA: 6,
+        hypocycloidB: 1
       }
     }
   }
@@ -36,10 +34,11 @@ export default class Star extends Shape {
     let points = []
     let a = parseFloat(state.shape.hypocycloidA)
     let b = parseFloat(state.shape.hypocycloidB)
+    let rotations = Number.isInteger(a/b) ? 1 : b
 
-    for (let i=0; i<128; i++) {
+    for (let i=0; i<128*rotations; i++) {
       let angle = Math.PI * 2.0 / 128.0 * i
-      let scale = 0.65
+      let scale = 0.18
       points.push(new Victor(scale * (a - b) * Math.cos(angle) + scale * b * Math.cos(((a - b) / b) * angle),
                          scale * (a - b) * Math.sin(angle) - scale * b * Math.sin(((a - b) / b) * angle)))
     }


### PR DESCRIPTION
This PR is a response to #130. To produce more pleasing art, when _a/b_ is a non-integer, will rotate _b_ times. I also made the two variables whole numbers instead of decimals. That makes it easier to replicate the examples on the Wolfram Alpha pages.

The shapes now produce quite different results than before with some values. My opinion is that this is an improvement and that shapes that need extra rotations look odd when they cannot complete. That said, it _is_ a change and I'm not sure if we need to worry about this?