### PR TITLE
new l-system shape; some l-system refactoring

### DIFF
--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -66,8 +66,8 @@ export const resizeVertices = (vertices, sizeX, sizeY) => {
   let scale = size/curveSize
 
   let scaledBounds = [bounds[0].multiply({x: scale, y: scale}), bounds[1].multiply({x: scale, y: scale})]
-  let deltaX = size - sizeX - scaledBounds[1].x - scaledBounds[0].x - 1
-  let deltaY = size - sizeY - scaledBounds[1].y - scaledBounds[0].y - 1
+  let deltaX = scaledBounds[1].x - (scaledBounds[1].x - scaledBounds[0].x)/2
+  let deltaY = scaledBounds[1].y - (scaledBounds[1].y - scaledBounds[0].y)/2
 
-  return vertices.map(vertex => vertex.multiply({x: scale, y: scale}).add({x: deltaX/2, y: deltaY/2}))
+  return vertices.map(vertex => vertex.multiply({x: scale, y: scale}).add({x: -deltaX, y: -deltaY}))
 }

--- a/src/common/lindenmayer.js
+++ b/src/common/lindenmayer.js
@@ -1,12 +1,42 @@
 import Victor from 'victor'
 
+export const onSubtypeChange = (subtype, changes, attrs) => {
+  // if we switch back with too many iterations, the code
+  // will crash from recursion, so we'll set a ceiling where needed
+  if (subtype) {
+    let max = subtype.maxIterations
+    let min = subtype.minIterations
+    let iterations = attrs.iterations || 1
+
+    if (max) {
+      iterations = Math.min(iterations, max)
+    }
+
+    if (min) {
+      iterations = Math.max(iterations, min)
+    }
+
+    changes.iterations = iterations
+  }
+
+  return changes
+}
+
+export const onMinIterations = (subtype, state) => {
+  return (subtype && subtype.minIterations) || 1
+}
+
+export const onMaxIterations = (subtype, state) => {
+  return (subtype && subtype.maxIterations) || 7
+}
+
 // Implements a Lindenmayer system (L-system). See https://en.wikipedia.org/wiki/L-system.
 // Adapted from http://bl.ocks.org/nitaku/ce638f8bd5e70cb809e1
 export const lsystem = (config) => {
   let input = config.axiom
   let output
 
-  for (let i=0; i<config.steps; i++) {
+  for (let i=0; i<config.iterations; i++) {
     output = ''
 
     for (let j=0; j<input.length; j++) {
@@ -27,7 +57,13 @@ export const lsystem = (config) => {
 export const lsystemPath = (instructions, config) => {
   let vertex = new Victor(0, 0)
   let vertices = [vertex]
-  let angle = config.startingAngle || -Math.PI/2
+  let angle = -Math.PI/2
+
+  if (config.startingAngle) {
+    angle = typeof config.startingAngle === 'function' ?
+      config.startingAngle(config.iterations) :
+      config.startingAngle
+  }
 
   for (let i=0; i<instructions.length; i++) {
     let char = instructions[i]

--- a/src/common/registeredShapes.js
+++ b/src/common/registeredShapes.js
@@ -1,17 +1,18 @@
-import Polygon from '../shapes/Polygon'
 import Circle from '../shapes/Circle'
-import Star from '../shapes/Star'
-import Heart from '../shapes/Heart'
-import Reuleaux from '../shapes/Reuleaux'
 import Epicycloid from '../shapes/Epicycloid'
-import Hypocycloid from '../shapes/Hypocycloid'
-import Rose from '../shapes/Rose'
-import InputText from '../shapes/input_text/InputText'
-import Wiper from '../shapes/Wiper'
-import V1Engineering from '../shapes/v1_engineering/V1Engineering'
 import FractalSpirograph from '../shapes/fractal_spirograph/FractalSpirograph'
-import TessellationTwist from '../shapes/tessellation_twist/TessellationTwist'
+import Heart from '../shapes/Heart'
+import Hypocycloid from '../shapes/Hypocycloid'
+import InputText from '../shapes/input_text/InputText'
+import LSystem from '../shapes/lsystem/LSystem'
+import Polygon from '../shapes/Polygon'
+import Reuleaux from '../shapes/Reuleaux'
+import Rose from '../shapes/Rose'
 import SpaceFiller from '../shapes/space_filler/SpaceFiller'
+import Star from '../shapes/Star'
+import TessellationTwist from '../shapes/tessellation_twist/TessellationTwist'
+import V1Engineering from '../shapes/v1_engineering/V1Engineering'
+import Wiper from '../shapes/Wiper'
 
 /*----------------------------------------------
 Supported input shapes
@@ -25,8 +26,9 @@ export const registeredShapes = {
   epicycloid: new Epicycloid(),
   hypocycloid: new Hypocycloid(),
   rose: new Rose(),
-  v1Engineering: new V1Engineering(),
   inputText: new InputText(),
+  v1Engineering: new V1Engineering(),
+  lsystem: new LSystem(),
   fractal_spirograph: new FractalSpirograph(),
   tessellation_twist: new TessellationTwist(),
   wiper: new Wiper(),

--- a/src/shapes/lsystem/LSystem.js
+++ b/src/shapes/lsystem/LSystem.js
@@ -6,8 +6,8 @@ import {
   onMinIterations,
   onMaxIterations
 } from '../../common/lindenmayer'
-import { resizeVertices } from '../../common/geometry'
 import { subtypes } from './subtypes'
+import { resizeVertices } from '../../common/geometry'
 
 const options = {
   ...shapeOptions,
@@ -28,57 +28,45 @@ const options = {
       max: (state) => {
         return onMaxIterations(subtypes[state.subtype], state)
       }
-    }
+    },
   }
 }
 
-export default class SpaceFiller extends Shape {
+export default class LSystem extends Shape {
   constructor() {
-    super('Space Filler')
-    this.linkText = 'Fractal charm: space filling curves'
-    this.link = 'https://www.youtube.com/watch?v=RU0wScIj36o'
+    super('Fractal Line Writer')
+    this.link = 'https://en.wikipedia.org/wiki/L-system'
+    this.linkText = 'this Wikipedia article on L-systems'
   }
 
   getInitialState() {
     return {
       ...super.getInitialState(),
       ...{
-        type: 'space_filler',
-        selectGroup: 'Erasers',
+        type: 'lsystem',
         repeatEnabled: false,
-        canTransform: false,
-        startingSize: 1,
-        canChangeSize: false,
-        iterations: 6,
-        subtype: 'Hilbert'
+        startingSize: 23,
+        iterations: 3,
+        subtype: 'McWorter\'s Pentadendrite'
       }
     }
   }
 
   getVertices(state) {
-    const machine = state.machine
     const shape = state.shape
     const iterations = shape.iterations || 1
-
-    let sizeX, sizeY
-    if (machine.rectangular) {
-      sizeX = machine.maxX - machine.minX
-      sizeY = machine.maxY - machine.minY
-    } else {
-      sizeX = sizeY = machine.maxRadius * 2.0
-    }
+    const size = 8
 
     // generate our vertices using a set of l-system rules
     let config = subtypes[shape.subtype]
     config.iterations = iterations
+    config.side = state.shape.startingSize/5
 
-    if (config.side === undefined) { config.side = 5 }
     if (config.angle === undefined) { config.angle = Math.PI/2 }
 
     let curve = lsystemPath(lsystem(config), config)
-    let scale = config.iterationsGrow ? iterations : 1
 
-    return resizeVertices(curve, sizeX*scale, sizeY*scale)
+    return resizeVertices(curve, size, size)
   }
 
   getOptions() {

--- a/src/shapes/lsystem/subtypes.js
+++ b/src/shapes/lsystem/subtypes.js
@@ -1,0 +1,159 @@
+// L-system instructions for space filling curves
+export const subtypes = {
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  '32-segment': {
+    axiom: 'F+F+F+F',
+    draw: ['F'],
+    rules:  {
+      F: '-F+F-F-F+F+FF-F+F+FF+F-F-FF+FF-FF+F+F-FF-F-F+FF-F-F+F+F-F+'
+    },
+    startingAngle: Math.PI,
+    maxIterations: 2
+  },
+  // http://www.kevs3d.co.uk/dev/lsystems/
+  'Cog Triangle': {
+    axiom: 'W----W----W----W',
+    draw: ['F'],
+    rules:  {
+      W: '+++X--F--ZFX+',
+      X: '---W++F++YFW-',
+      Y: '+ZFX--F--Z+++',
+      Z: '-YFW++F++Y---'
+    },
+    angle: Math.PI/6,
+    minIterations: 1,
+    maxIterations: 8
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'Gosper (flowsnake)': {
+    axiom: 'A',
+    draw: ['A', 'B'],
+    rules:  {
+      A: 'A-B--B+A++AA+B-',
+      B: '+A-BB--B-A++A+B'
+    },
+    angle: Math.PI / 3,
+    maxIterations: 5
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'Ice': {
+    axiom: 'F+F+F+F',
+    draw: ['F'],
+    rules:  {
+      F: 'FF+F++F+F'
+    },
+    startingAngle: Math.PI,
+    maxIterations: 6
+  },
+  // https://onlinemathtools.com/l-system-generator
+  'Koch Curve': {
+    axiom: 'F',
+    draw: ['F'],
+    rules:  {
+      F: 'F+F--F+F'
+    },
+    angle: 4*Math.PI/9,
+    startingAngle: Math.PI,
+    maxIterations: 7
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'Koch Island': {
+    axiom: 'F+F+F+F',
+    draw: ['F'],
+    rules:  {
+      F: 'F+F-F-FF+F+F-F'
+    },
+    startingAngle: Math.PI,
+    maxIterations: 4
+  },
+  'Koch Snowflake': {
+    axiom: 'F--F--F--',
+    draw: ['F'],
+    rules:  {
+      F: 'F+F--F+F'
+    },
+    angle: Math.PI / 3,
+    startingAngle: -Math.PI / 3,
+    maxIterations: 5
+  },
+  // https://fronkonstin.com/2017/06/26/a-shiny-app-to-draw-curves-based-on-l-systems/
+  'Koch Variation 1': {
+    axiom: 'F-F-F-F',
+    draw: ['F'],
+    rules:  {
+      F: 'FF-F-F-F-FF',
+    },
+    maxIterations: 5
+  },
+  // https://fronkonstin.com/2017/06/26/a-shiny-app-to-draw-curves-based-on-l-systems/
+  'Koch Variation 2': {
+    axiom: 'F-F-F-F',
+    draw: ['F'],
+    rules:  {
+      F: 'FF-F-F-F-F-F+F',
+    },
+    maxIterations: 4
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'McWorter\'s Pentadendrite': {
+    axiom: 'F-F-F-F-F',
+    draw: ['F'],
+    rules:  {
+      F: 'F-F-F++F+F-F',
+    },
+    angle: 2*Math.PI/5,
+    maxIterations: 5
+  },
+  // cannot do this until we support branching with legal vertex moves
+  // https://onlinemathtools.com/l-system-generator
+  // 'Penrose Tile': {
+  //   axiom: '[7]++[7]++[7]++[7]++[7]',
+  //   draw: ['6', '7', '8', '9'],
+  //   rules: {
+  //     6: '8++9----7[-8----6]++',
+  //     7: '+8--9[---6--7]+',
+  //     8: '-6++7[+++8++9]-',
+  //     9: '--8++++6[+9++++7]--7'
+  //   },
+  //   angle: Math.PI/5
+  //},
+  'Plusses': {
+    axiom: 'XYXYXYX+XYXYXYX+XYXYXYX+XYXYXYX',
+    draw: ['F'],
+    rules:  {
+      X: 'FX+FX+FXFY-FY-',
+      Y: '+FX+FXFY-FY-FY'
+    },
+    maxIterations: 4
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'Red Dragon': {
+    axiom: 'FA',
+    draw: ['F'],
+    rules:  {
+      A: 'A+BF+',
+      B: '-FA-B'
+    },
+    minIterations: 9,
+    maxIterations: 15,
+    startingAngle: Math.PI
+  },
+  // http://mathforum.org/advanced/robertd/lsys2d.html
+  'Sierpinski Triangle (arrowhead)': {
+    axiom: 'X',
+    draw: ['X', 'Y'],
+    rules:  {
+      X: 'Y+X+Y',
+      Y: 'X-Y-X'
+    },
+    angle: Math.PI / 3,
+    startingAngle: (i) => {
+      if (i % 2 === 0) {
+        return 0
+      } else {
+        return -Math.PI/3
+      }
+    },
+    maxIterations: 8
+  },
+}

--- a/src/shapes/lsystem/subtypes.js
+++ b/src/shapes/lsystem/subtypes.js
@@ -12,7 +12,7 @@ export const subtypes = {
   },
   // http://www.kevs3d.co.uk/dev/lsystems/
   'Cog Triangle': {
-    axiom: 'W----W----W----W',
+    axiom: 'W----W----W',
     draw: ['F'],
     rules:  {
       W: '+++X--F--ZFX+',

--- a/src/shapes/space_filler/subtypes.js
+++ b/src/shapes/space_filler/subtypes.js
@@ -1,6 +1,5 @@
 // L-system instructions for space filling curves
-
-export const fillers = {
+export const subtypes = {
   // http://mathforum.org/advanced/robertd/lsys2d.html
   'Gosper (flowsnake)': {
     axiom: 'A',
@@ -10,8 +9,8 @@ export const fillers = {
       B: '+A-BB--B-A++A+B'
     },
     angle: Math.PI / 3,
-    orderGrow: true,
-    maxOrder: 6
+    iterationsGrow: true,
+    maxIterations: 6
   },
   // http://mathforum.org/advanced/robertd/lsys2d.html
   'Hilbert': {
@@ -32,9 +31,10 @@ export const fillers = {
       Y: 'YFXFY-F-XFYFX+F+YFXFY'
     },
     startingAngle: Math.PI,
-    maxOrder: 4
+    maxIterations: 4
   },
-
+// cannot do this until we support branching with legal vertex moves
+// https://onlinemathtools.com/l-system-generator
 //  'Penrose Tile': {
 //    axiom: '[7]++[7]++[7]++[7]++[7]',
 //    draw: ['6', '7', '8', '9'],
@@ -56,7 +56,7 @@ export const fillers = {
     },
     startingAngle: Math.PI/4,
     angle: Math.PI/4,
-    maxOrder: 6
+    maxIterations: 6
   },
 
   // https://en.wikipedia.org/wiki/Sierpi%C5%84ski_curve
@@ -67,6 +67,6 @@ export const fillers = {
       X: 'XF-F+F-XF+F+XF-F+F-X'
     },
     startingAngle: Math.PI/4,
-    maxOrder: 6
+    maxIterations: 6
   }
 }


### PR DESCRIPTION
This PR takes the l-system introduced in the Space Filler shape, and repurposes it as a general shape. This gives us more flexibility in the types of fractal patterns we can create. I've added a number of "classic" fractals.

For the future:

- I would like to allow users to do their own L-system programming, but that's more complex and can come downstream of these stock shapes.
- The current l-system does not yet support branching and a few other cool options that would let us build more patterns. In the case of branching, it does not always produce valid (single-line) patterns when it branches and we'll need to modify a bit if we want to support.