### PR TITLE
fix weirdness with perimeter detection

### DIFF
--- a/src/features/machine/Machine.js
+++ b/src/features/machine/Machine.js
@@ -1,8 +1,11 @@
+import { vertexRoundP } from '../../common/geometry'
+
 // base machine class
 export default class Machine {
   polish() {
     return this.enforceLimits()
       .cleanVertices()
+      .limitPrecision()
       .optimizePerimeter()
       .addEndpoints()
   }
@@ -159,5 +162,12 @@ export default class Machine {
     }
 
     return walked
+  }
+
+  // round each vertex to the nearest .001. This eliminates floating point
+  // math errors and allows us to do accurate equality comparisons.
+  limitPrecision() {
+    this.vertices = this.vertices.map(vertex => vertexRoundP(vertex, 3))
+    return this
   }
 }

--- a/src/features/machine/PolarMachine.js
+++ b/src/features/machine/PolarMachine.js
@@ -88,13 +88,13 @@ export default class PolarMachine extends Machine {
   }
 
   // Returns whether a given path lies on the perimeter of the circle.
-  onPerimeter(v1, v2, delta=.001) {
+  onPerimeter(v1, v2, delta=1) {
     let rm = Math.pow(this.settings.maxRadius, 2)
     let r1 = Math.pow(v1.x, 2) + Math.pow(v1.y, 2)
     let r2 = Math.pow(v2.x, 2) + Math.pow(v2.y, 2)
     let d = this.perimeterDistance(v1, v2)
 
-    return (r1 >= rm - delta && r2 >= rm - delta) && d < 15
+    return Math.abs(r1 - rm) < delta && Math.abs(r2 - rm) < delta && d < 4*Math.PI
   }
 
   // The guts of logic for this limits enforcer. It will take a single line (defined by

--- a/src/features/machine/PolarMachine.js
+++ b/src/features/machine/PolarMachine.js
@@ -94,7 +94,14 @@ export default class PolarMachine extends Machine {
     let r2 = Math.pow(v2.x, 2) + Math.pow(v2.y, 2)
     let d = this.perimeterDistance(v1, v2)
 
-    return Math.abs(r1 - rm) < delta && Math.abs(r2 - rm) < delta && d < 4*Math.PI
+    // Delta is purposefully large to accommodate the squaring of the compared values.
+    // Setting delta too small will result in perimeter moves being miscategorized.
+    // d is used to guard against the case where there is a straight line connecting two
+    // perimeter points directly. In this case, we want to register that as a non-perimeter
+    // move, or it will be incorrectly optimized out of the final vertices. The 3/50
+    // ratio could likely be refined further (relative to maxRadius), but it seems to produce
+    // accurate results at various machine sizes.
+    return Math.abs(r1 - rm) < delta && Math.abs(r2 - rm) < delta && d < 3*this.settings.maxRadius/50
   }
 
   // The guts of logic for this limits enforcer. It will take a single line (defined by

--- a/src/features/machine/RectMachine.js
+++ b/src/features/machine/RectMachine.js
@@ -61,15 +61,11 @@ export default class RectMachine extends Machine {
   }
 
   // Returns whether a given path lies on the perimeter of the rectangle
-  onPerimeter(v1, v2, delta=.00001) {
+  onPerimeter(v1, v2, delta=.0001) {
     const dx = Math.abs(Math.abs(v1.x) - this.sizeX)
     const dy = Math.abs(Math.abs(v1.y) - this.sizeY)
 
-    if ((v1.x === v2.x && dx < delta) || (v1.y === v2.y && dy < delta)) {
-      return v1.x === v2.x || v1.y === v2.y
-    } else {
-      return false
-    }
+    return (v1.x === v2.x && dx < delta) || (v1.y === v2.y && dy < delta)
   }
 
   // Given two perimeter points, traces the shortest valid path between them (stays on

--- a/src/features/machine/RectMachine.js
+++ b/src/features/machine/RectMachine.js
@@ -64,8 +64,10 @@ export default class RectMachine extends Machine {
   onPerimeter(v1, v2, delta=.0001) {
     const dx = Math.abs(Math.abs(v1.x) - this.sizeX)
     const dy = Math.abs(Math.abs(v1.y) - this.sizeY)
+    const rDx = Math.abs(v1.x - v2.x)
+    const rDy = Math.abs(v1.y - v2.y)
 
-    return (v1.x === v2.x && dx < delta) || (v1.y === v2.y && dy < delta)
+    return (rDx < delta && dx < delta) || (rDy < delta && dy < delta)
   }
 
   // Given two perimeter points, traces the shortest valid path between them (stays on


### PR DESCRIPTION
This PR fixes a few edge cases where perimeter optimization does not work as expected. It has the pleasant side effect of "maxing out" the perimeter distance if you start to draw shape lines entirely out of bounds. I don't think limiting vertex precision to .001 will affect other shapes, but let me know.