### PR TITLE
Trying out caching of shape vertices.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.2.5",
     "color": "^3.1.2",
-    "gcode-toolpath": "^2.2.0",
     "core-js": "^3.6.5",
+    "gcode-toolpath": "^2.2.0",
     "jest-canvas-mock": "^2.2.0",
     "lodash": "^4.17.15",
+    "lru-cache": "^5.1.1",
     "node-sass": "^4.13.1",
     "rc-slider": "^8.6.3",
     "react": "^16.13.0",

--- a/src/features/machine/selectors.js
+++ b/src/features/machine/selectors.js
@@ -31,6 +31,9 @@ export const getShapedVertices = createSelector(
       machine: machine
     }
     const metashape = getShape(shape)
+    if (shape.shouldCache) {
+      return metashape.getVerticesWithCache(state)
+    }
     return metashape.getVertices(state)
   }
 )

--- a/src/models/Shape.js
+++ b/src/models/Shape.js
@@ -26,18 +26,6 @@ export default class Shape {
     return shapeOptions
   }
 
-  getVerticesWithCache(state) {
-    this.cache.forEach( (cachedShape) => {
-      var [shape, vertices] = cachedShape
-      if (JSON.stringify(state.shape) === JSON.stringify(shape)) {
-        return vertices
-      }
-    })
-    const shapeVertices = this.getVertices(state)
-    this.cache.push([state.shape, shapeVertices])
-    return shapeVertices
-  }
-
   getVertices(state) {
     return []
   }

--- a/src/models/Shape.js
+++ b/src/models/Shape.js
@@ -3,6 +3,7 @@ export const shapeOptions = {}
 export default class Shape {
   constructor(name) {
     this.name = name
+    this.cache = []
   }
 
   getInitialState() {
@@ -10,6 +11,7 @@ export default class Shape {
       repeatEnabled: true,
       canTransform: true,
       selectGroup: 'Shapes',
+      shouldCache: true,
     }
   }
 
@@ -22,6 +24,18 @@ export default class Shape {
 
   getOptions() {
     return shapeOptions
+  }
+
+  getVerticesWithCache(state) {
+    this.cache.forEach( (cachedShape) => {
+      var [shape, vertices] = cachedShape
+      if (JSON.stringify(state.shape) === JSON.stringify(shape)) {
+        return vertices
+      }
+    })
+    const shapeVertices = this.getVertices(state)
+    this.cache.push([state.shape, shapeVertices])
+    return shapeVertices
   }
 
   getVertices(state) {

--- a/src/models/Wiper.js
+++ b/src/models/Wiper.js
@@ -253,7 +253,8 @@ export default class Wiper extends Shape {
         wiperSize: 12,
         wiperType: 'Lines',
         selectGroup: 'Erasers',
-        canTransform: false
+        canTransform: false,
+        shouldCache: false,
       }
     }
   }

--- a/src/models/lsystem/subtypes.js
+++ b/src/models/lsystem/subtypes.js
@@ -32,7 +32,7 @@ export const subtypes = {
       F: 'F[+FF][-FF]F[-F][+F]F',
     },
     angle: Math.PI/5,
-    maxIterations: 4
+    maxIterations: 5
   },
   // https://www.vexlio.com/blog/drawing-simple-organics-with-l-systems/
   'Fractal Tree 2': {
@@ -42,7 +42,7 @@ export const subtypes = {
       F: 'F[-F][+F]',
     },
     angle: 10*Math.PI/72,
-    maxIterations: 8
+    maxIterations: 9
   },
   // https://www.vexlio.com/blog/drawing-simple-organics-with-l-systems/
   'Fractal Tree 3': {
@@ -53,7 +53,7 @@ export const subtypes = {
       X: 'F+[-F-XF-X][+FF][--XF[+X]][++F-X]'
     },
     angle: Math.PI/8,
-    maxIterations: 4
+    maxIterations: 6
   },
   // https://www.vexlio.com/blog/drawing-simple-organics-with-l-systems/
   'Fractal Tree 4': {
@@ -65,7 +65,7 @@ export const subtypes = {
       Z: '[+F-X-F][++ZX]'
     },
     angle: Math.PI/8,
-    maxIterations: 4
+    maxIterations: 5
   },
   // http://algorithmicbotany.org/papers/abop/abop-ch1.pdf
   'Fractal Tree 5': {
@@ -76,7 +76,7 @@ export const subtypes = {
       F: 'FF'
     },
     angle: Math.PI/9,
-    maxIterations: 7
+    maxIterations: 8
   },
   // http://mathforum.org/advanced/robertd/lsys2d.html
   'Gosper (flowsnake)': {

--- a/src/models/space_filler/SpaceFiller.js
+++ b/src/models/space_filler/SpaceFiller.js
@@ -46,7 +46,6 @@ export default class SpaceFiller extends Shape {
         type: 'space_filler',
         selectGroup: 'Erasers',
         canTransform: false,
-        shouldCache: false,
         iterations: 6,
         subtype: 'Hilbert'
       }

--- a/src/models/space_filler/SpaceFiller.js
+++ b/src/models/space_filler/SpaceFiller.js
@@ -46,6 +46,7 @@ export default class SpaceFiller extends Shape {
         type: 'space_filler',
         selectGroup: 'Erasers',
         canTransform: false,
+        shouldCache: false,
         iterations: 6,
         subtype: 'Hilbert'
       }


### PR DESCRIPTION
#139 

This seems to work. I put in some console.log statements and I can tell it is returning the cache. It is also much faster on some of the fractal line patterns.

I think we can safely bump some of those up as much as it makes sense. If you want @bobnik, maybe you could take a look at this branch, and while you are at it, adjust the max for those lines to be where you want them? Even if this completely makes the performance fine (which it probably doesn't). I think there is still probably a reasonable max for the patterns.

I also turned off the caching of the space filler l system. I figured that since it uses the machine limits, the caching wouldn't really make sense, and it would probably be an enormous cache to cache every machine size. 