### PR TITLE
Rounded corners on polygons.

### DIFF
--- a/src/models/Polygon.js
+++ b/src/models/Polygon.js
@@ -7,7 +7,18 @@ const options = {
     polygonSides: {
       title: 'Number of sides',
       min: 3
-    }
+    },
+    roundCorners: {
+      title: 'Round Corners',
+      type: 'checkbox',
+    },
+    roundFraction: {
+      title: 'Round Fraction',
+      min: 0.0,
+      max: 1.0,
+      step: 0.05,
+      isVisible: (state) => { return state.roundCorners }
+    },
   }
 }
 
@@ -21,16 +32,56 @@ export default class Polygon extends Shape {
       ...super.getInitialState(),
       ...{
         type: 'polygon',
-        polygonSides: 4
+        polygonSides: 4,
+        roundCorners: false,
+        roundFraction: 0.5,
       }
     }
   }
 
+  // Returns a list of points from (start, end] along the line.
+  getLineVertices(startPoint, endPoint, numberOfPoints) {
+    const resolution = 1.0/numberOfPoints
+    let points = []
+    for (let d=resolution; d<=1.0; d+=resolution) {
+      points.push(new Victor(startPoint.x + (endPoint.x - startPoint.x)*d,
+                             startPoint.y + (endPoint.y - startPoint.y)*d))
+    }
+    return points
+  }
+
   getVertices(state) {
+    // beta is the fraction to have rounded.
+    const beta = state.shape.roundFraction
+    // alpha is the fration to have straight.
+    const alpha = (1.0-beta)
     let points = []
     for (let i=0; i<=state.shape.polygonSides; i++) {
-      let angle = Math.PI * 2.0 / state.shape.polygonSides * (0.5 + i)
-      points.push(new Victor(Math.cos(angle), Math.sin(angle)))
+      const angle = Math.PI * 2.0 / state.shape.polygonSides * (0.5 + i)
+      if (state.shape.roundCorners && beta !== 0.0) {
+        // angles that make up the arc.
+        const angleStart = Math.PI * 2.0 / state.shape.polygonSides * i
+        const angleEnd = Math.PI * 2.0 / state.shape.polygonSides * (i + 1)
+        const angleResolution = 0.10
+        if (points.length > 0) {
+          // Start with a line. We use a bunch of points for this, so they get stretch about evenly
+          // as the curves do.
+          const numberOfLinePoints = (angleEnd - angleStart)/angleResolution/beta
+          points = points.concat(this.getLineVertices(points[points.length-1],
+                                                      new Victor(alpha * Math.cos(angle) + beta * Math.cos(angleStart),
+                                                                 alpha * Math.sin(angle) + beta * Math.sin(angleStart)),
+                                                      numberOfLinePoints))
+        }
+        if (i !== state.shape.polygonSides) {
+          // Create the arc.
+          for (let arcAngle=angleStart + angleResolution; arcAngle<=angleEnd; arcAngle += angleResolution) {
+            points.push(new Victor(alpha * Math.cos(angle) + beta * Math.cos(arcAngle), alpha * Math.sin(angle) + beta * Math.sin(arcAngle)))
+          }
+        }
+      } else {
+        // Not rounded corners.
+        points.push(new Victor(Math.cos(angle), Math.sin(angle)))
+      }
     }
     return points
   }

--- a/src/models/Polygon.js
+++ b/src/models/Polygon.js
@@ -9,14 +9,14 @@ const options = {
       min: 3
     },
     roundCorners: {
-      title: 'Round Corners',
+      title: 'Round corners',
       type: 'checkbox',
     },
     roundFraction: {
-      title: 'Round Fraction',
-      min: 0.0,
-      max: 1.0,
-      step: 0.05,
+      title: 'Round fraction',
+      min: 0.05,
+      max: 0.5,
+      step: 0.025,
       isVisible: (state) => { return state.roundCorners }
     },
   }
@@ -34,7 +34,7 @@ export default class Polygon extends Shape {
         type: 'polygon',
         polygonSides: 4,
         roundCorners: false,
-        roundFraction: 0.5,
+        roundFraction: 0.25,
       }
     }
   }


### PR DESCRIPTION
Creates round corners (part of #117).

Since we don't handle arcs any differently, and we smear evenly based on the vertex index, leaving the line segments as lines means they get skewed funny compared to the arcs. Ideally, the arc length is basically the same as the line length, which I think I have gotten close to. But the result is a 4 vertex shape just became a 200 vertex shape. Not a huge deal, but it's frustrating we can't smear an arc more smoothly.