### PR TITLE
Feature/variable pre post

### DIFF
--- a/src/features/exporter/Exporter.js
+++ b/src/features/exporter/Exporter.js
@@ -5,16 +5,13 @@ export default class Exporter {
   }
 
   export() {
+    this.pre = this.props.pre
+    this.post = this.props.post
     let vertices = this.props.vertices
     if (this.props.reverse) {
       vertices = vertices.reverse()
     }
-
-    this.pre = this.props.pre
-    this.post = this.props.post
-    if (vertices.lenth !== 0) {
-      this.variableReplace(vertices)
-    }
+    this.computeOutputVertices(vertices)
 
     this.header()
     this.startComments()
@@ -34,7 +31,7 @@ export default class Exporter {
     }
 
     this.line()
-    this.exportCode(vertices)
+    this.exportCode(this.vertices)
     this.line()
 
     if (this.post !== '') {
@@ -60,8 +57,9 @@ export default class Exporter {
     // default does nothing
   }
 
-  variableReplace(vertices) {
+  computeOutputVertices(vertices) {
     // default does nothing
+    this.vertices = vertices
   }
 
   line(content='', add=true) {

--- a/src/features/exporter/Exporter.js
+++ b/src/features/exporter/Exporter.js
@@ -5,6 +5,17 @@ export default class Exporter {
   }
 
   export() {
+    let vertices = this.props.vertices
+    if (this.props.reverse) {
+      vertices = vertices.reverse()
+    }
+
+    this.pre = this.props.pre
+    this.post = this.props.post
+    if (vertices.lenth !== 0) {
+      this.variableReplace(vertices)
+    }
+
     this.header()
     this.startComments()
     this.props.comments.forEach( comment => this.line(comment) )
@@ -12,30 +23,25 @@ export default class Exporter {
     this.keyValueLine('File name', "'" + this.props.fileName + "'")
     this.line()
     this.endComments()
-    if (this.props.pre !== '') {
+    if (this.pre !== '') {
       this.startComments()
       this.line('BEGIN PRE')
       this.endComments()
-      this.line(this.props.pre, this.props.pre !== '')
+      this.line(this.pre, this.pre !== '')
       this.startComments()
       this.line('END PRE')
       this.endComments()
-    }
-
-    let vertices = this.props.vertices
-    if (this.props.reverse) {
-      vertices = vertices.reverse()
     }
 
     this.line()
     this.exportCode(vertices)
     this.line()
 
-    if (this.props.post !== '') {
+    if (this.post !== '') {
       this.startComments()
       this.line('BEGIN POST')
       this.endComments()
-      this.line(this.props.post, this.props.post !== '')
+      this.line(this.post, this.post !== '')
       this.startComments()
       this.line('END POST')
       this.endComments()
@@ -51,6 +57,10 @@ export default class Exporter {
   }
 
   footer() {
+    // default does nothing
+  }
+
+  variableReplace(vertices) {
     // default does nothing
   }
 

--- a/src/features/exporter/Exporter.js
+++ b/src/features/exporter/Exporter.js
@@ -8,18 +8,19 @@ export default class Exporter {
     this.pre = this.props.pre
     this.post = this.props.post
     let vertices = this.props.vertices
+
     if (this.props.reverse) {
       vertices = vertices.reverse()
     }
     this.computeOutputVertices(vertices)
-
     this.header()
     this.startComments()
-    this.props.comments.forEach( comment => this.line(comment) )
+    this.props.comments.forEach(comment => this.line(comment))
     this.line()
     this.keyValueLine('File name', "'" + this.props.fileName + "'")
     this.line()
     this.endComments()
+
     if (this.pre !== '') {
       this.startComments()
       this.line('BEGIN PRE')

--- a/src/features/exporter/GCodeExporter.js
+++ b/src/features/exporter/GCodeExporter.js
@@ -20,6 +20,42 @@ export default class GCodeExporter extends Exporter {
     centeredVertices.map(this.gcode).forEach(line => this.line(line))
   }
 
+  variableReplace(vertices) {
+    // Collect some statistics about these vertices.
+    let startx = vertices[0].x + this.props.offsetX
+    let starty = vertices[0].y + this.props.offsetY
+    let endx = vertices[vertices.length-1].x + this.props.offsetX
+    let endy = vertices[vertices.length-1].y + this.props.offsetY
+    let minx = 1e9
+    let miny = 1e9
+    let maxx = -1e9
+    let maxy = -1e9
+    vertices.forEach( (vertex) => {
+      minx = Math.min(vertex.x + this.props.offsetX, minx)
+      miny = Math.min(vertex.y + this.props.offsetY, miny)
+      maxx = Math.max(vertex.x + this.props.offsetX, maxx)
+      maxy = Math.max(vertex.y + this.props.offsetY, maxy)
+    })
+
+    // Replace these strings.
+    this.pre  =  this.pre.replace(/{startx}/gi, startx.toFixed(3))
+    this.pre  =  this.pre.replace(/{starty}/gi, starty.toFixed(3))
+    this.pre  =  this.pre.replace(/{endx}/gi,   endx.toFixed(3))
+    this.pre  =  this.pre.replace(/{endy}/gi,   endy.toFixed(3))
+    this.pre  =  this.pre.replace(/{minx}/gi,   minx.toFixed(3))
+    this.pre  =  this.pre.replace(/{miny}/gi,   miny.toFixed(3))
+    this.pre  =  this.pre.replace(/{maxx}/gi,   maxx.toFixed(3))
+    this.pre  =  this.pre.replace(/{maxy}/gi,   maxy.toFixed(3))
+    this.post = this.post.replace(/{startx}/gi, startx.toFixed(3))
+    this.post = this.post.replace(/{starty}/gi, starty.toFixed(3))
+    this.post = this.post.replace(/{endx}/gi,   endx.toFixed(3))
+    this.post = this.post.replace(/{endy}/gi,   endy.toFixed(3))
+    this.post = this.post.replace(/{minx}/gi,   minx.toFixed(3))
+    this.post = this.post.replace(/{miny}/gi,   miny.toFixed(3))
+    this.post = this.post.replace(/{maxx}/gi,   maxx.toFixed(3))
+    this.post = this.post.replace(/{maxy}/gi,   maxy.toFixed(3))
+  }
+
   gcode(vertex) {
     let command = 'G01' +
       ' X' + vertex.x.toFixed(3) +

--- a/src/features/exporter/GCodeExporter.js
+++ b/src/features/exporter/GCodeExporter.js
@@ -12,19 +12,22 @@ export default class GCodeExporter extends Exporter {
     vertices.map(this.gcode).forEach(line => this.line(line))
   }
 
+  // computes vertices compatible with the gcode format, and replaces
+  // placeholder variables in pre/post blocks.
   computeOutputVertices(vertices) {
     // Collect some statistics about these vertices.
     let minx = 1e9
     let miny = 1e9
     let maxx = -1e9
     let maxy = -1e9
-    this.vertices = vertices.map( (vertex) => {
+    this.vertices = vertices.map(vertex => {
       const x = vertex.x + this.props.offsetX
       const y = vertex.y + this.props.offsetY
       minx = Math.min(x, minx)
       miny = Math.min(y, miny)
       maxx = Math.max(x, maxx)
       maxy = Math.max(y, maxy)
+
       return {
         ...vertex,
         x: x,
@@ -36,7 +39,7 @@ export default class GCodeExporter extends Exporter {
     let endx = this.vertices[this.vertices.length-1].x
     let endy = this.vertices[this.vertices.length-1].y
 
-    // Replace these strings.
+    // Replace pre/post placeholder variables
     this.pre  =  this.pre.replace(/{startx}/gi, startx.toFixed(3))
     this.pre  =  this.pre.replace(/{starty}/gi, starty.toFixed(3))
     this.pre  =  this.pre.replace(/{endx}/gi,   endx.toFixed(3))

--- a/src/features/exporter/GCodeExporter.js
+++ b/src/features/exporter/GCodeExporter.js
@@ -9,33 +9,32 @@ export default class GCodeExporter extends Exporter {
   }
 
   exportCode(vertices) {
-    var centeredVertices = vertices.map( (vertex) => {
-      return {
-        ...vertex,
-        x: vertex.x + this.props.offsetX,
-        y: vertex.y + this.props.offsetY,
-      }
-    })
-
-    centeredVertices.map(this.gcode).forEach(line => this.line(line))
+    vertices.map(this.gcode).forEach(line => this.line(line))
   }
 
-  variableReplace(vertices) {
+  computeOutputVertices(vertices) {
     // Collect some statistics about these vertices.
-    let startx = vertices[0].x + this.props.offsetX
-    let starty = vertices[0].y + this.props.offsetY
-    let endx = vertices[vertices.length-1].x + this.props.offsetX
-    let endy = vertices[vertices.length-1].y + this.props.offsetY
     let minx = 1e9
     let miny = 1e9
     let maxx = -1e9
     let maxy = -1e9
-    vertices.forEach( (vertex) => {
-      minx = Math.min(vertex.x + this.props.offsetX, minx)
-      miny = Math.min(vertex.y + this.props.offsetY, miny)
-      maxx = Math.max(vertex.x + this.props.offsetX, maxx)
-      maxy = Math.max(vertex.y + this.props.offsetY, maxy)
+    this.vertices = vertices.map( (vertex) => {
+      const x = vertex.x + this.props.offsetX
+      const y = vertex.y + this.props.offsetY
+      minx = Math.min(x, minx)
+      miny = Math.min(y, miny)
+      maxx = Math.max(x, maxx)
+      maxy = Math.max(y, maxy)
+      return {
+        ...vertex,
+        x: x,
+        y: y,
+      }
     })
+    let startx = this.vertices[0].x
+    let starty = this.vertices[0].y
+    let endx = this.vertices[this.vertices.length-1].x
+    let endy = this.vertices[this.vertices.length-1].y
 
     // Replace these strings.
     this.pre  =  this.pre.replace(/{startx}/gi, startx.toFixed(3))

--- a/src/features/exporter/ThetaRhoExporter.js
+++ b/src/features/exporter/ThetaRhoExporter.js
@@ -13,7 +13,8 @@ export default class ThetaRhoExporter extends Exporter {
     this.commentChar = '#'
   }
 
-  // adds lines mapping given vertices to the theta rho format
+  // computes vertices compatible with the theta rho format, and replaces
+  // placeholder variables in pre/post blocks.
   computeOutputVertices(vertices) {
     // First, downsample larger lines into smaller ones.
     const maxLength = 2.0
@@ -40,17 +41,15 @@ export default class ThetaRhoExporter extends Exporter {
       previous = next
     }
 
-    // Add in the end.
+    // Add in the end
     if (previous !== undefined) {
       subsampledVertices.push(vertices[vertices.length - 1])
     }
 
-    // Convert to Theta, Rho
+    // Convert to theta, rho
     this.vertices = []
     let previousTheta = 0
     let previousRawTheta = 0
-
-
     let mintheta = 1e9
     let minrho   = 1e9
     let maxtheta = -1e9
@@ -64,7 +63,7 @@ export default class ThetaRhoExporter extends Exporter {
       // What is the basic theta for this point?
       let rawTheta = Math.atan2(subsampledVertices[next].x,
                                 subsampledVertices[next].y)
-      // Convert to [0,2pi]
+      // Convert to [0, 2pi]
       rawTheta = (rawTheta + 2.0 * Math.PI) % (2.0 * Math.PI)
 
       // Compute the difference to the last point.
@@ -85,12 +84,13 @@ export default class ThetaRhoExporter extends Exporter {
       previousTheta = theta
       this.vertices.push(new Victor(theta, rho))
     }
+
     let starttheta = this.vertices[0].x
     let startrho   = this.vertices[0].y
     let endtheta   = this.vertices[this.vertices.length-1].x
     let endrho     = this.vertices[this.vertices.length-1].y
 
-    // Replace these strings.
+    // Replace pre/post placeholder variables
     this.pre  =  this.pre.replace(/{starttheta}/gi, starttheta.toFixed(3))
     this.pre  =  this.pre.replace(/{startrho}/gi,   startrho.toFixed(3))
     this.pre  =  this.pre.replace(/{endtheta}/gi,   endtheta.toFixed(3))


### PR DESCRIPTION
Fixes #154. I pasted an example of what it looks like there.

I managed to get theta/rho to work without much trouble.

Some thoughts on this:
1. This is a completely undocumented feature. There isn't a good way for anyone to stumble into this. I am seriously considering making documenation for sandify. It is getting pretty complicated, and a little bit of documentation could go a long way. I would love to give some examples of good pre/post for people with sand tables, or people who want to use their CNC machine to plot with these patterns.
2. I am not sold on the naming scheme of these. It is just a case insensitive string. So I could have also done `{start x}`, which would also match with `{Start X}`. Or `start_x`, or `start-x`.
3. There is a lot of repetition in this code, but I couldn't think of a better way to do it. Maybe there is a more ES6/Javascript way to do this.

This is sort of a "vendetta" feature for me. Because I want to be able to plot a bunch of these neat patterns we've made, and I'd like to do something like this:

```
G1 Z10 F400 ; pen up
; Trace the boundary, so you can check for paper alignment
G1 X{minx} Y{miny} F2000
G1 X{maxx} Y{miny}
G1 X{maxx} Y{maxy}
G1 X{minx} Y{maxy}
G1 X{minx} Y{miny}
; Go to the start
G1 X{startx} Y{starty}
G1 Z-0.1; pen down
G1 F2000 ; set speed
```

