### PR TITLE
fix key; export starting size in comments

### DIFF
--- a/src/features/exporter/CommentExporter.js
+++ b/src/features/exporter/CommentExporter.js
@@ -39,7 +39,7 @@ export default class CommentExporter extends Exporter {
 
         this.keyValueLine('Selected Shape', shape.name)
         this.optionLines(shape, instance, Object.keys(options))
-        this.optionLines(transform, state.transform, ['offsetX', 'offsetY'])
+        this.optionLines(transform, state.transform, ['startingSize', 'offsetX', 'offsetY'])
         this.optionLines(transform, state.transform, ['numLoops', 'transformMethod', 'spinEnabled'], state.transform.repeatEnabled)
         this.indent()
         this.optionLines(transform, state.transform, ['spinValue', 'spinMethod'], state.transform.repeatEnabled && state.transform.spinEnabled)

--- a/src/features/machine/selectors.js
+++ b/src/features/machine/selectors.js
@@ -118,7 +118,7 @@ export const getVertices = createSelector(
     }
 
     const hasImported = (state.app.input === 'code' || state.importer.fileName)
-    if (state.app.input === 'shapes' || !hasImported) {
+    if (state.app.input === 'shape' || !hasImported) {
       if (dragging) {
         return getTransformedVertices(state)
       } else {


### PR DESCRIPTION
This PR fixes an issue where after an import, the Shapes tab used the imported vertices incorrectly.

I ran into a second issue where if I export from a rectangular machine using theta rho, the exported shape shrinks (seen if you re-import). It has to do with how we calculate maxRadius when the machine is rectangular, which affects the rho value. Anyway, I believe you (Jeff) have flagged this before, but do we need to support the export of theta rho on a rectangular machine? If so, we probably should fix this export issue separately.