### PR TITLE
allow insertion of new layer after current one

### DIFF
--- a/src/features/layers/Playlist.js
+++ b/src/features/layers/Playlist.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Accordion, Button, Card, ListGroup, Modal, Row, Col, Form } from 'react-bootstrap'
+import { Accordion, Button, Card, ListGroup, Modal, Row, Col, Form, ToggleButton, ToggleButtonGroup } from 'react-bootstrap'
 import Select from 'react-select'
 import { SortableContainer, SortableElement } from 'react-sortable-hoc'
 import { FaTrash, FaEye, FaEyeSlash, FaCopy } from 'react-icons/fa';
@@ -24,7 +24,9 @@ const mapStateToProps = (state, ownProps) => {
     newLayerType: state.layers.newLayerType,
     newLayerName: state.layers.newLayerName,
     newLayerNameOverride: state.layers.newLayerNameOverride,
+    newLayerInsert: state.layers.newLayerInsert,
     copyLayerName: state.layers.copyLayerName,
+    copyLayerInsert: state.layers.copyLayerInsert,
     selectOptions: getShapeSelectOptions()
   }
 }
@@ -58,8 +60,14 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onChangeNewName: (event) => {
       dispatch(updateLayers({ newLayerName: event.target.value, newLayerNameOverride: true }))
     },
+    onChangeNewInsert: (value) => {
+      dispatch(updateLayers({ newLayerInsert: value }))
+    },
     onChangeCopyName: (event) => {
       dispatch(updateLayers({ copyLayerName: event.target.value }))
+    },
+    onChangeCopyInsert: (value) => {
+      dispatch(updateLayers({ copyLayerInsert: value }))
     },
     onLayerMoved: ({oldIndex, newIndex}) => {
       dispatch(moveLayer({oldIndex: oldIndex, newIndex: newIndex}))
@@ -235,6 +243,17 @@ class Playlist extends Component {
                 />
               </Col>
             </Row>
+            <Row className="align-items-center mt-2">
+              <Col sm={5}>
+                Insert layer
+              </Col>
+              <Col sm={7}>
+                <ToggleButtonGroup id="newLayerInsert" type="radio" name="newLayerInsert" value={this.props.newLayerInsert} onChange={this.props.onChangeNewInsert}>
+                  <ToggleButton variant="light" value="end">at end</ToggleButton>
+                  <ToggleButton variant="light" value="current">after current layer</ToggleButton>
+                </ToggleButtonGroup>
+              </Col>
+            </Row>
           </Modal.Body>
 
           <Modal.Footer>
@@ -315,6 +334,17 @@ class Playlist extends Component {
                   onFocus={this.handleNameFocus}
                   onChange={this.props.onChangeCopyName}
                 />
+              </Col>
+            </Row>
+            <Row className="align-items-center mt-2">
+              <Col sm={5}>
+                Insert layer
+              </Col>
+              <Col sm={7}>
+                <ToggleButtonGroup id="copyLayerInsert" type="radio" name="copyLayerInsert" value={this.props.copyLayerInsert} onChange={this.props.onChangeCopyInsert}>
+                  <ToggleButton variant="light" value="end">at end</ToggleButton>
+                  <ToggleButton variant="light" value="current">after current layer</ToggleButton>
+                </ToggleButtonGroup>
               </Col>
             </Row>
           </Modal.Body>

--- a/src/features/layers/layersSlice.js
+++ b/src/features/layers/layersSlice.js
@@ -17,22 +17,29 @@ const layersSlice = createSlice({
     selected: null,
     newLayerType: newLayerType,
     newLayerName: newLayerName,
+    newLayerInsert: 'end',
     newLayerNameOverride: false,
     copyLayerName: null,
+    copyLayerInsert: 'end',
     byId: {},
     allIds: []
   },
   reducers: {
     addLayer(state, action) {
       let layer = { ...action.payload }
+      const index = state.newLayerInsert === 'current' ?
+        state.allIds.findIndex(id => id === state.current) + 1 :
+        state.allIds.length
+
       layer.id = uniqueId('layer-')
       layer.name = layer.name || state.newLayerName
       state.byId[layer.id] = layer
-      state.allIds.push(layer.id)
+      state.allIds.splice(index, 0, layer.id)
       state.current = layer.id
       state.selected = layer.id
       state.newLayerNameOverride = false
       state.newLayerName = layer.name
+
       if (layer.type !== 'file_import' && !layer.effect) {
         localStorage.setItem('currentShape', layer.type)
       }
@@ -44,9 +51,13 @@ const layersSlice = createSlice({
     copyLayer(state, action) {
       const source = state.byId[action.payload]
       const layer = { ...source, name: state.copyLayerName }
+      const index = state.copyLayerInsert === 'current' ?
+        state.allIds.findIndex(id => id === state.current) + 1 :
+        state.allIds.length
+
       layer.id = uniqueId('layer-')
       state.byId[layer.id] = layer
-      state.allIds.push(layer.id)
+      state.allIds.splice(index, 0, layer.id)
       state.current = layer.id
       state.selected = layer.id
     },

--- a/src/features/layers/layersSlice.spec.js
+++ b/src/features/layers/layersSlice.spec.js
@@ -72,7 +72,9 @@ describe('layers reducer', () => {
       newLayerType: 'polygon',
       newLayerName: 'polygon',
       newLayerNameOverride: false,
+      newLayerInsert: 'end',
       copyLayerName: null,
+      copyLayerInsert: 'end',      
       byId: {},
       allIds: []
     })

--- a/src/features/transforms/Transforms.js
+++ b/src/features/transforms/Transforms.js
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onRepeat: () => {
       dispatch(toggleRepeat({id: id}))
     },
-    ontransformMethodChange: (value) => {
+    onTransformMethodChange: (value) => {
       dispatch(updateLayer({ transformMethod: value, id: id}))
     }
   }
@@ -126,7 +126,7 @@ class Transforms extends Component {
                     </Col>
 
                     <Col sm={7}>
-                      <ToggleButtonGroup id="transformMethod" type="radio" name="transformMethod" value={this.props.layer.transformMethod} onChange={this.props.ontransformMethodChange}>
+                      <ToggleButtonGroup id="transformMethod" type="radio" name="transformMethod" value={this.props.layer.transformMethod} onChange={this.props.onTransformMethodChange}>
                         <ToggleButton variant="light" value="smear">smear</ToggleButton>
                         <ToggleButton variant="light" value="intact">keep intact</ToggleButton>
                       </ToggleButtonGroup>


### PR DESCRIPTION
Allows insertion of a new layer after the current one, which is something that becomes quite useful when you start having a large number of layers. Prior to this PR, you have to carefully drag each new layer to the right place.