### PR TITLE
when adding a new layer, insert after current one (vs at end)

### DIFF
--- a/src/features/layers/layersSlice.js
+++ b/src/features/layers/layersSlice.js
@@ -28,7 +28,10 @@ const layersSlice = createSlice({
       layer.id = uniqueId('layer-')
       layer.name = layer.name || state.newLayerName
       state.byId[layer.id] = layer
-      state.allIds.push(layer.id)
+
+      const index = state.allIds.findIndex(id => id === state.current) + 1
+      state.allIds.splice(index, 0, layer.id)
+
       state.current = layer.id
       state.selected = layer.id
       state.newLayerNameOverride = false
@@ -46,7 +49,10 @@ const layersSlice = createSlice({
       const layer = { ...source, name: state.copyLayerName }
       layer.id = uniqueId('layer-')
       state.byId[layer.id] = layer
-      state.allIds.push(layer.id)
+
+      const index = state.allIds.findIndex(id => id === state.current) + 1
+      state.allIds.splice(index, 0, layer.id)
+
       state.current = layer.id
       state.selected = layer.id
     },

--- a/src/features/layers/layersSlice.spec.js
+++ b/src/features/layers/layersSlice.spec.js
@@ -112,6 +112,7 @@ describe('layers reducer', () => {
           }
         },
         allIds: ['layer-1'],
+        current: 'layer-1',
         copyLayerName: 'foo'
       },
       copyLayer('layer-1'))


### PR DESCRIPTION
Pared down version of #191. When adding new layer, add after current one, not at end.