### PR TITLE
Feature/inverted mask

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gcode-toolpath": "^2.2.0",
     "jest-canvas-mock": "^2.2.0",
     "konva": "^5.0.2",
+    "liang-barsky": "^1.0.4",
     "lodash": "^4.17.19",
     "lru-cache": "^5.1.1",
     "mathjs": "^6.6.4",

--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -185,7 +185,7 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
 
   for (let next = 0; next < subsampledVertices.length; ++next) {
 
-    const rho = (Victor.fromObject(subsampledVertices[next]).magnitude() / maxRadius) * rhoMax
+    let rho = (Victor.fromObject(subsampledVertices[next]).magnitude() / maxRadius) * rhoMax
     rho = Math.min(rho, rhoMax)
 
     // What is the basic theta for this point?

--- a/src/features/exporter/ThetaRhoExporter.js
+++ b/src/features/exporter/ThetaRhoExporter.js
@@ -60,7 +60,8 @@ export default class ThetaRhoExporter extends Exporter {
       if (rhoMax < 0) { rhoMax = 0.1 }
       if ( rhoMax > 1) { rhoMax = 1.0 }
 
-      const rho = (Victor.fromObject(subsampledVertices[next]).magnitude() / this.props.maxRadius) * rhoMax
+      let rho = (Victor.fromObject(subsampledVertices[next]).magnitude() / this.props.maxRadius) * rhoMax
+      rho = Math.min(rho, rhoMax)
       minrho = Math.min(rho, minrho)
       maxrho = Math.max(rho, maxrho)
 

--- a/src/features/layers/layersSlice.js
+++ b/src/features/layers/layersSlice.js
@@ -5,7 +5,7 @@ import { getShape } from '../../models/shapes'
 
 const protectedAttrs = [
   'repeatEnabled', 'canTransform', 'selectGroup', 'canChangeSize', 'autosize',
-  'usesMachine', 'shouldCache', 'rotateCompleteLoop', 'canChangeHeight', 'canRotate'
+  'usesMachine', 'shouldCache', 'canChangeHeight', 'canRotate'
 ]
 const newLayerType = localStorage.getItem('currentShape') || 'polygon'
 const newLayerName = getShape({type: newLayerType}).name.toLowerCase()

--- a/src/features/layers/layersSlice.spec.js
+++ b/src/features/layers/layersSlice.spec.js
@@ -41,7 +41,6 @@ describe('layers reducer', () => {
     backtrackPct: 0,
     drawPortionPct: 100,
     effect: false,
-    rotateCompleteLoop: false,
     rotateStartingPct: 0,
     growEnabled: true,
     growValue: 100,

--- a/src/features/machine/Machine.js
+++ b/src/features/machine/Machine.js
@@ -5,8 +5,8 @@ export default class Machine {
   // given a set of vertices, ensure they adhere to the limits defined by the machine
   polish() {
     this.enforceLimits()
-      .cleanVertices()
       .limitPrecision()
+      .cleanVertices()
       .optimizePerimeter()
 
     if (this.layerInfo.border) this.outlinePerimeter()
@@ -16,22 +16,22 @@ export default class Machine {
     return this
   }
 
-  // clean the list of vertices and remove duplicate points
+  // clean the list of vertices and remove (nearly) duplicate points
   cleanVertices() {
     let previous = null
     let cleanVertices = []
 
     for (let i=0; i<this.vertices.length; i++) {
-      if (previous) {
-        let start = this.vertices[i]
-        let end = previous
+      const curr = this.vertices[i]
 
-        if (start.distance(end) > 0.001) {
-          cleanVertices.push(this.nearestVertex(this.vertices[i]))
+      if (previous) {
+        if (curr.distance(previous) > 0.001) {
+          cleanVertices.push(curr)
         }
       } else {
-        cleanVertices.push(this.nearestVertex(this.vertices[i]))
+        cleanVertices.push(curr)
       }
+
       previous = this.vertices[i]
     }
 
@@ -87,7 +87,8 @@ export default class Machine {
       curr = this.vertices[currentIndex]
 
       if (previous) {
-        const clipped = this.clipLine(previous, curr)
+        // rounding here to deal with some erratic perimeter lines
+        let clipped = this.clipLine(previous, curr).map(pt => vertexRoundP(pt, 3))
 
         if (clipped.length > 0 && this.inBounds(previous) && cleanVertices.length > 0) {
           const perimeter = this.tracePerimeter(cleanVertices[cleanVertices.length - 1], clipped[0])

--- a/src/features/machine/Machine.js
+++ b/src/features/machine/Machine.js
@@ -68,7 +68,7 @@ export default class Machine {
 
 // walk the given vertices, removing all vertices that lie within the machine limits
   enforceInvertedLimits() {
-    if (this.vertices.length === 0) return
+    if (this.vertices.length === 0) return this
 
     let cleanVertices = []
     let currentIndex = 0

--- a/src/features/machine/Machine.js
+++ b/src/features/machine/Machine.js
@@ -5,7 +5,6 @@ export default class Machine {
   // given a set of vertices, ensure they adhere to the limits defined by the machine
   polish() {
     this.enforceLimits()
-      .limitPrecision()
       .cleanVertices()
       .optimizePerimeter()
 
@@ -13,7 +12,7 @@ export default class Machine {
     if (this.layerInfo.start) this.addStartPoint()
     if (this.layerInfo.end) this.addEndPoint()
 
-    return this
+    return this.limitPrecision()
   }
 
   // clean the list of vertices and remove (nearly) duplicate points
@@ -52,7 +51,7 @@ export default class Machine {
 
         for (let pt=0; pt<line.length; pt++) {
           if (line[pt] !== previous) {
-            cleanVertices.push(line[pt])
+            cleanVertices.push(this.nearestVertex(line[pt]))
           }
         }
       } else {

--- a/src/features/machine/Machine.js
+++ b/src/features/machine/Machine.js
@@ -94,7 +94,10 @@ export default class Machine {
           cleanVertices = [...cleanVertices, ...perimeter]
         }
 
-        cleanVertices = [...cleanVertices, ...clipped]
+        // slightly awkward syntax so that we can use splice to add our clipped
+        // array directly to cleanVertices and avoid a shallow array copy.
+        const args = [cleanVertices.length, 0].concat(clipped)
+        Array.prototype.splice.apply(cleanVertices, args)
 
       } else {
         cleanVertices.push(curr)

--- a/src/features/machine/PolarInvertedMachine.js
+++ b/src/features/machine/PolarInvertedMachine.js
@@ -40,7 +40,7 @@ export default class PolarInvertedMachine extends PolarMachine {
     const intersections = this.getIntersections(start, end)
     if (!intersections.intersection) {
       if (log) { console.log('line is outside limits') }
-      return [start, end]
+      return [end]
     }
 
     if (intersections.points[0].on && intersections.points[1].on) {

--- a/src/features/machine/PolarInvertedMachine.js
+++ b/src/features/machine/PolarInvertedMachine.js
@@ -1,0 +1,73 @@
+import PolarMachine from './PolarMachine'
+import Victor from 'victor'
+
+// Machine that clips vertices that fall inside the machine limits
+export default class PolarInvertedMachine extends PolarMachine {
+  constructor(vertices, settings, layerInfo={}) {
+    super(vertices, settings, layerInfo)
+  }
+
+  // Walk the given vertices, clipping as needed along the perimeter
+  enforceLimits() {
+    return this.enforceInvertedLimits()
+  }
+
+  // Finds the nearest vertex that is in the bounds of the circle. This will change the
+  // shape. i.e. this doesn't care about the line segment, only about the point.
+  nearestVertex(vertex) {
+    const size = this.settings.maxRadius
+
+    if ( vertex.length() < size) {
+      const scale = size / vertex.length()
+      return vertex.multiply(new Victor(scale, scale))
+    } else {
+      return vertex
+    }
+  }
+
+  // Take a given line, and if the line goes out of bounds, returns the vertices
+  // around the outside edge to follow around without messing up the shape of the vertices.
+  clipLine(start, end, log=false) {
+    const size = this.settings.maxRadius
+    const radStart = start.magnitude()
+    const radEnd = end.magnitude()
+
+    if (radStart < size && radEnd < size) {
+      if (log) { console.log('line is inside limits') }
+      return []
+    }
+
+    const intersections = this.getIntersections(start, end)
+    if (!intersections.intersection) {
+      if (log) { console.log('line is outside limits') }
+      return [start, end]
+    }
+
+    if (intersections.points[0].on && intersections.points[1].on) {
+      let point = intersections.points[0].point
+      let otherPoint = intersections.points[1].point
+
+      if (log) { console.log('line is outside limits, but intersects within limits') }
+      return [
+        ...this.tracePerimeter(point, otherPoint),
+        otherPoint,
+        end
+      ]
+    }
+
+    if (radStart <= size) {
+      const point1 = (intersections.points[0].on && Math.abs(intersections.points[0].point - start) > 0.0001) ? intersections.points[0].point : intersections.points[1].point
+      if (log) { console.log('start is inside limits') }
+      return [ point1, end ]
+    } else {
+      const point1 = intersections.points[0].on ? intersections.points[0].point : intersections.points[1].point
+      if (log) { console.log('end is inside limits') }
+      return [ start, point1 ]
+    }
+  }
+
+  // Returns the vertex if it's outside the bounds of the circle.
+  inBounds(vertex) {
+    return vertex.length() < this.settings.maxRadius
+  }
+}

--- a/src/features/machine/PolarMachine.js
+++ b/src/features/machine/PolarMachine.js
@@ -177,7 +177,7 @@ export default class PolarMachine extends Machine {
     }
 
     // If both points are outside, but there's an intersection
-    if (radStart > size && radEnd > size) {
+    if (radStart > size + 1.0e-9 && radEnd > size + 1.0e-9) {
       let point = intersections.points[0].point
       let otherPoint = intersections.points[1].point
 

--- a/src/features/machine/PolarMachine.js
+++ b/src/features/machine/PolarMachine.js
@@ -65,8 +65,11 @@ export default class PolarMachine extends Machine {
   nearestVertex(vertex) {
     const size = this.settings.maxRadius
 
-    if ( vertex.length() > size) {
-      const scale = size / vertex.length()
+    if (vertex.length() > size) {
+      // try to prevent floating point math from pushing us out of bounds
+      const precisionModifier = 0.0001
+      const scale = (size - precisionModifier) / vertex.length()
+
       return vertex.multiply(new Victor(scale, scale))
     } else {
       return vertex

--- a/src/features/machine/PolarMachine.js
+++ b/src/features/machine/PolarMachine.js
@@ -164,7 +164,8 @@ export default class PolarMachine extends Machine {
        return [this.nearestVertex(start)]
     }
 
-    let intersections = this.getIntersections(start, end)
+    const intersections = this.getIntersections(start, end)
+
     if (!intersections.intersection) {
       // The whole line is outside, just trace.
       return this.tracePerimeter(start, end)
@@ -176,7 +177,7 @@ export default class PolarMachine extends Machine {
     }
 
     // If both points are outside, but there's an intersection
-    if (radStart > size + 1.0e-9 && radEnd > size + 1.0e-9) {
+    if (radStart > size && radEnd > size) {
       let point = intersections.points[0].point
       let otherPoint = intersections.points[1].point
 
@@ -189,12 +190,12 @@ export default class PolarMachine extends Machine {
 
     // If we're here, then one point is still in the circle.
     if (radStart <= size) {
-      let point1 = (intersections.points[0].on && Math.abs(intersections.points[0].point - start) > 0.0001) ? intersections.points[0].point : intersections.points[1].point
+      const point1 = (intersections.points[0].on && Math.abs(intersections.points[0].point - start) > 0.0001) ? intersections.points[0].point : intersections.points[1].point
 
       return [
         start,
         ...this.tracePerimeter(point1, end),
-        end
+        this.nearestPerimeterVertex(end)
       ]
     } else {
       const point1 = intersections.points[0].on ? intersections.points[0].point : intersections.points[1].point
@@ -221,21 +222,30 @@ export default class PolarMachine extends Machine {
       }
     }
 
-    let dt = Math.sqrt(size*size - distanceToLine*distanceToLine)
-    let point1 = direction.clone().multiply(Victor(t - dt,t - dt)).add(start)
-    let point2 = direction.clone().multiply(Victor(t + dt,t + dt)).add(start)
+    const dt = Math.sqrt(size*size - distanceToLine*distanceToLine)
+    const point1 = direction.clone().multiply(Victor(t - dt,t - dt)).add(start)
+    const point2 = direction.clone().multiply(Victor(t + dt,t + dt)).add(start)
+    const s1 = onSegment(start, end, point1)
+    const s2 = onSegment(start, end, point2)
 
-    return {
-      intersection: true,
-      points: [
-        {
-          point: point1,
-          on: onSegment(start, end, point1),
-        },
-        {
-          point: point2,
-          on: onSegment(start, end, point2),
-        }
-      ]}
+    if (s1 || s2) {
+      return {
+        intersection: true,
+        points: [
+          {
+            point: point1,
+            on: s1
+          },
+          {
+            point: point2,
+            on: s2
+          }
+        ]}
+    } else {
+      return {
+        intersection: false,
+        points: [],
+      }
+    }
   }
 }

--- a/src/features/machine/RectInvertedMachine.js
+++ b/src/features/machine/RectInvertedMachine.js
@@ -1,0 +1,61 @@
+import RectMachine from './RectMachine'
+import Victor from 'victor'
+import clip from 'liang-barsky'
+
+// Machine that clips vertices that fall inside the machine limits
+export default class RectInvertedMachine extends RectMachine {
+  constructor(vertices, settings, layerInfo={}) {
+    super(vertices, settings, layerInfo)
+  }
+
+  enforceLimits() {
+    return this.enforceInvertedLimits()
+  }
+
+  clipLine(start, end, log=true) {
+    const quadrantStart = this.pointLocation(start)
+    const quadrantEnd = this.pointLocation(end)
+
+    if (quadrantStart === 0b0000 && quadrantEnd === 0b0000) {
+      if (log) { console.log('line is inside limits') }
+      return []
+    }
+
+    let a = [start.x, start.y]
+    let b = [end.x, end.y]
+    const bounds = [-this.sizeX, -this.sizeY, this.sizeX, this.sizeY]
+    const clipped = clip(a, b, bounds)
+
+    if (quadrantStart === 0b000) {
+      if (log) { console.log('start is inside limits') }
+      return [new Victor(b[0], b[1]), end]
+    }
+
+    if (quadrantEnd === 0b000) {
+      if (log) { console.log('end is inside limits') }
+      return [start, new Victor(a[0], a[1])]
+    }
+
+    if (clipped) {
+      if (log) { console.log('line is outside limits, but intersects within limits') }
+      return [
+        start,
+        ...this.tracePerimeter(new Victor(a[0], a[1]), new Victor(b[0], b[1]), true),
+        end
+      ]
+    } else {
+      if (log) { console.log('line is outside limits') }
+      return [start, end]
+    }
+  }
+
+  // Finds the nearest vertex that is in the bounds. This will change the shape. i.e. this
+  // doesn't care about the line segment, only about the point.
+  nearestVertex(vertex) {
+    if (this.pointLocation(vertex) === 0b0000) {
+      return this.nearestPerimeterVertex(vertex)
+    } else {
+      return vertex
+    }
+  }
+}

--- a/src/features/machine/RectInvertedMachine.js
+++ b/src/features/machine/RectInvertedMachine.js
@@ -12,7 +12,7 @@ export default class RectInvertedMachine extends RectMachine {
     return this.enforceInvertedLimits()
   }
 
-  clipLine(start, end, log=true) {
+  clipLine(start, end, log=false) {
     const quadrantStart = this.pointLocation(start)
     const quadrantEnd = this.pointLocation(end)
 

--- a/src/features/machine/computer.js
+++ b/src/features/machine/computer.js
@@ -156,18 +156,6 @@ export const transformShapes = (vertices, layer, effects) => {
     vertices.pop()
   }
 
-  if (layer.rotateStartingPct === undefined || layer.rotateStartingPct !== 0) {
-    const start = Math.round(vertices.length * layer.rotateStartingPct / 100.0)
-    vertices = arrayRotate(vertices, start)
-
-    // some patterns create a loop when drawn and transformMethod is 'intact'; in
-    // this case, rotateStartingPct will not draw the final vertex to complete the
-    // loop. Use rotateCompleteLoop to add it back in for specific shapes.
-    if (layer.rotateCompleteLoop) {
-      vertices.push(new Victor(vertices[0].x, vertices[0].y))
-    }
-  }
-
   if (layer.trackEnabled && numTrackLoops > 1) {
     for (var i=0; i<numLoops; i++) {
       for (var t=0; t<numTrackLoops; t++) {
@@ -176,14 +164,25 @@ export const transformShapes = (vertices, layer, effects) => {
     }
   } else {
     for (i=0; i<numLoops; i++) {
-      const drawPortionPct = Math.round((layer.drawPortionPct || 100)/100.0 * vertices.length)
-      const completion = i === numLoops - 1 ? drawPortionPct : vertices.length
-
-      for (var j=0; j<completion; j++) {
+      for (var j=0; j<vertices.length; j++) {
         let amount = layer.transformMethod === 'smear' ? i + j/vertices.length : i
         outputVertices.push(transformShape(layer, vertices[j], amount, amount))
       }
     }
+  }
+
+  if (layer.rotateStartingPct === undefined || layer.rotateStartingPct !== 0) {
+    console.log('here!')
+    const start = Math.round(outputVertices.length * layer.rotateStartingPct / 100.0)
+    console.log(outputVertices[0])
+    outputVertices = arrayRotate(outputVertices, start)
+    console.log(start)
+    console.log(outputVertices[0])
+  }
+
+  if (layer.drawPortionPct !== undefined) {
+    const drawPortionPct = Math.round((parseInt(layer.drawPortionPct) || 100)/100.0 * outputVertices.length)
+    outputVertices = outputVertices.slice(0, drawPortionPct)
   }
 
   if (layer.reverse) {

--- a/src/features/machine/computer.js
+++ b/src/features/machine/computer.js
@@ -172,12 +172,8 @@ export const transformShapes = (vertices, layer, effects) => {
   }
 
   if (layer.rotateStartingPct === undefined || layer.rotateStartingPct !== 0) {
-    console.log('here!')
     const start = Math.round(outputVertices.length * layer.rotateStartingPct / 100.0)
-    console.log(outputVertices[0])
     outputVertices = arrayRotate(outputVertices, start)
-    console.log(start)
-    console.log(outputVertices[0])
   }
 
   if (layer.drawPortionPct !== undefined) {

--- a/src/features/preview/PreviewLayer.js
+++ b/src/features/preview/PreviewLayer.js
@@ -160,12 +160,13 @@ const PreviewLayer = (ownProps) => {
         moveTo_mm(context, sliderEnd)
         context.strokeStyle = selectedColor
         dot_mm(context, sliderEnd)
+
+        // START: uncomment these lines to show slider end point coordinates
+        // context.font = '12px Arial'
+        // context.fillText('(' + sliderEnd.x.toFixed(2) + ', ' + sliderEnd.y.toFixed(2) + ')', sliderEnd.x, -sliderEnd.y)
+        // END
       }
 
-      // START: uncomment these lines to show slider end point coordinates
-      // context.font = '20px Arial'
-      // context.fillText('(' + sliderEndPoint.x.toFixed(2) + ', ' + sliderEndPoint.y.toFixed(2) + ')', 10, 50)
-      // END
       context.stroke()
     }
   }

--- a/src/models/Epicycloid.js
+++ b/src/models/Epicycloid.js
@@ -30,7 +30,6 @@ export default class Epicycloid extends Shape {
         type: 'epicycloid',
         epicycloidA: 4,
         epicycloidB: 1,
-        rotateCompleteLoop: true
       }
     }
   }

--- a/src/models/Freeform.js
+++ b/src/models/Freeform.js
@@ -1,0 +1,43 @@
+import Victor from 'victor'
+import Shape, { shapeOptions } from './Shape'
+
+const options = {
+  ...shapeOptions,
+  ...{
+    freeformPoints: {
+      title: 'Points',
+      type: 'input'
+    }
+  }
+}
+
+export default class Freeform extends Shape {
+  constructor() {
+    super('Freeform')
+  }
+
+  getInitialState() {
+    return {
+      ...super.getInitialState(),
+      ...{
+        type: 'freeform',
+        freeformPoints: '-1,-1;-1,1;1,1',
+        repeatEnabled: false,
+        canChangeHeight: false,
+        startingWidth: 50,
+        startingHeight: 50
+      },
+    }
+  }
+
+  getVertices(state) {
+    return state.shape.freeformPoints.split(';').map((pair) => {
+      const coordinates = pair.split(',')
+      return new Victor(coordinates[0], coordinates[1])
+    })
+  }
+
+  getOptions() {
+    return options
+  }
+}

--- a/src/models/Hypocycloid.js
+++ b/src/models/Hypocycloid.js
@@ -30,7 +30,6 @@ export default class Star extends Shape {
         type: 'hypocycloid',
         hypocycloidA: 6,
         hypocycloidB: 1,
-        rotateCompleteLoop: true        
       }
     }
   }

--- a/src/models/Mask.js
+++ b/src/models/Mask.js
@@ -4,6 +4,8 @@ import Effect from './Effect'
 import { rotate, offset, circle } from '../common/geometry'
 import PolarMachine from '../features/machine/PolarMachine'
 import RectMachine from '../features/machine/RectMachine'
+import PolarInvertedMachine from '../features/machine/PolarInvertedMachine'
+import RectInvertedMachine from '../features/machine/RectInvertedMachine'
 
 const options = {
   ...shapeOptions,
@@ -33,6 +35,10 @@ const options = {
       title: 'Try to minimize perimeter moves',
       type: 'checkbox'
     },
+    maskInvert: {
+      title: 'Invert',
+      type: 'checkbox'
+    },
     maskBorder: {
       title: 'Draw border',
       type: 'checkbox'
@@ -55,7 +61,8 @@ export default class Mask extends Effect {
         startingHeight: 100,
         maskMinimizeMoves: false,
         maskMachine: 'rectangle',
-        maskBorder: false
+        maskBorder: false,
+        maskInvert: false
       }
     }
   }
@@ -83,7 +90,9 @@ export default class Mask extends Effect {
     })
 
     if (!layer.dragging && !effect.dragging) {
-      const machineClass = effect.maskMachine === 'circle' ? PolarMachine : RectMachine
+      const machineClass = effect.maskMachine === 'circle' ?
+        (effect.maskInvert ? PolarInvertedMachine : PolarMachine) :
+        (effect.maskInvert ? RectInvertedMachine : RectMachine)
 
       const machine = new machineClass(
         vertices,

--- a/src/models/NoiseWave.js
+++ b/src/models/NoiseWave.js
@@ -57,7 +57,18 @@ export default class NoiseWave extends Shape {
   }
 
   getVertices(state) {
-    const machine = state.machine
+    // without this adjustment, using an inverted circular mask causes clipping issues
+    const adjustment = .001
+
+    const machine = {
+      maxRadius: state.machine.maxRadius - adjustment,
+      rectangular: state.machine.rectangular,
+      minX: state.machine.minX,
+      maxX: state.machine.maxX,
+      minY: state.machine.minY,
+      maxY: state.machine.maxY
+    }
+
     const shape = state.shape
     const rng = seedrandom(shape.seed)
     let vertices = []

--- a/src/models/Polygon.js
+++ b/src/models/Polygon.js
@@ -35,7 +35,6 @@ export default class Polygon extends Shape {
         polygonSides: 4,
         roundCorners: false,
         roundFraction: 0.25,
-        rotateCompleteLoop: true
       }
     }
   }

--- a/src/models/Rose.js
+++ b/src/models/Rose.js
@@ -32,7 +32,6 @@ export default class Rose extends Shape {
         roseN: 3,
         roseD: 2,
         transformMethod: 'intact',
-        rotateCompleteLoop: true
       }
     }
   }

--- a/src/models/Shape.js
+++ b/src/models/Shape.js
@@ -49,7 +49,6 @@ export default class Shape {
       connectionMethod: 'line',
       drawPortionPct: 100,
       backtrackPct: 0,
-      rotateCompleteLoop: false,
       rotateStartingPct: 0,
       reverse: false,
       dragging: false,

--- a/src/models/Star.js
+++ b/src/models/Star.js
@@ -28,7 +28,6 @@ export default class Star extends Shape {
         type: 'star',
         points: 5,
         starRatio: 0.5,
-        rotateCompleteLoop: true        
       }
     }
   }

--- a/src/models/Transform.js
+++ b/src/models/Transform.js
@@ -34,19 +34,19 @@ const transformOptions = {
     title: 'Backtrack at end (%)',
     min: 0,
     max: 100,
-    step: 5
+    step: 2
   },
   drawPortionPct: {
     title: 'Draw portion of path (%)',
     min: 0,
     max: 100,
-    step: 5
+    step: 2
   },
   rotateStartingPct: {
     title: 'Rotate starting point (%)',
     min: -100,
     max: 100,
-    step: 5
+    step: 2
   },
   reverse: {
     title: 'Reverse path',
@@ -110,9 +110,6 @@ const transformOptions = {
   },
   trackGrowEnabled: {
     title: 'Scale track'
-  },
-  rotateCompleteLoop: {
-    title: 'Complete loop?'
   },
   trackValue: {
     title: 'Track size',

--- a/src/models/fractal_spirograph/FractalSpirograph.js
+++ b/src/models/fractal_spirograph/FractalSpirograph.js
@@ -49,7 +49,6 @@ export default class FractalSpirograph extends Shape {
         fractalSpirographRelativeSize: 3,
         fractalSpirographAlternateRotation: true,
         repeatEnabled: false,
-        rotateCompleteLoop: true        
       }
     }
   }

--- a/src/models/shapes.js
+++ b/src/models/shapes.js
@@ -3,6 +3,7 @@ import Epicycloid from '../models/Epicycloid'
 import FileImport from '../models/FileImport'
 import Fisheye from '../models/Fisheye'
 import FractalSpirograph from '../models/fractal_spirograph/FractalSpirograph'
+// import Freeform from '../models/Freeform'
 import Heart from '../models/Heart'
 import Hypocycloid from '../models/Hypocycloid'
 import InputText from '../models/input_text/InputText'
@@ -37,6 +38,7 @@ export const registeredShapes = {
   fractal_spirograph: new FractalSpirograph(),
   tessellation_twist: new TessellationTwist(),
   point: new Point(),
+  // freeform: new Freeform(),
   wiper: new Wiper(),
   space_filler: new SpaceFiller(),
   noise_wave: new NoiseWave(),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3259145/107151554-31844c80-6931-11eb-9ab6-6a823937ae2a.png)

This PR introduces the concept of an inverted mask (setting on the Mask shape). It works for both polar and rect masks, and can be nested with other masks to create some interesting clipping effects. I've done a reasonable amount of testing of the mask with different shapes, but please put it through its paces.

I've also added a Freeform shape, which I used to test the new machine logic. It's not really intended for end-user usage, so I've commented it out, but I can see an enhanced version of something like it eventually becoming an end-user shape.

Lastly, I made small corrections to the original boundary logic - hopefully I didn't break anything.