### PR TITLE
use arrow keys to change offsets in machine preview

### DIFF
--- a/src/features/preview/MachinePreview.js
+++ b/src/features/preview/MachinePreview.js
@@ -4,12 +4,18 @@ import Slider from 'rc-slider'
 import 'rc-slider/assets/index.css'
 import PreviewWindow from './PreviewWindow'
 import Downloader from '../exporter/Downloader'
+import { getCurrentLayer } from '../layers/selectors'
+import { updateLayer } from '../layers/layersSlice'
 import { updatePreview } from './previewSlice'
 import { getVerticesStats } from '../machine/selectors'
 import './MachinePreview.scss'
 
 const mapStateToProps = (state, ownProps) => {
+  const current = getCurrentLayer(state)
+
   return {
+    currentLayer: current,
+    currentLayerSelected: state.layers.selected === current.id,
     sliderValue: state.preview.sliderValue,
     verticesStats: getVerticesStats(state),
   }
@@ -20,13 +26,44 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onSlider: (value) => {
       dispatch(updatePreview({sliderValue: value}))
     },
+    onLayerChange: (attrs) => {
+      dispatch(updateLayer(attrs))
+    },
+    onKeyDown: (event, currentLayer) => {
+      let attrs = { id: currentLayer.id }
+
+      if (['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+        const delta = !!event.shiftKey ? 1 : 5
+
+        if (event.key === 'ArrowDown') {
+          attrs.offsetY = currentLayer.offsetY - delta
+        } else if (event.key === 'ArrowUp') {
+          attrs.offsetY = currentLayer.offsetY + delta
+        } else if (event.key === 'ArrowLeft') {
+          attrs.offsetX = currentLayer.offsetX - delta
+        } else if (event.key === 'ArrowRight') {
+          attrs.offsetX = currentLayer.offsetX + delta
+        }
+
+        dispatch(updateLayer(attrs))
+      }
+    }
   }
 }
 
 class MachinePreview extends Component {
+  componentDidMount() {
+    // ensures that arrow keys always work
+    this.el.focus()
+  }
+
   render() {
     return (
-      <div className="machine-preview d-flex flex-grow-1 flex-column" id="machine-preview">
+      <div className="machine-preview d-flex flex-grow-1 flex-column" id="machine-preview" ref={(el) => { this.el = el }} tabIndex={0} onKeyDown={e => {
+        if (this.props.currentLayerSelected) {
+          this.props.onKeyDown(e, this.props.currentLayer)
+        }
+      }}>
         <div className="flex-grow-1 d-flex flex-column">
           <div id="preview-wrapper" className="preview-wrapper d-flex flex-column align-items-center">
             <PreviewWindow />

--- a/src/features/preview/MachinePreview.scss
+++ b/src/features/preview/MachinePreview.scss
@@ -15,3 +15,7 @@
     height: calc(100vh - 169px);
   }
 }
+
+.machine-preview {
+  outline: none;
+}

--- a/src/features/preview/PreviewLayer.js
+++ b/src/features/preview/PreviewLayer.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch, shallowEqual } from 'react-redux'
 import { Shape, Transformer } from 'react-konva'
 import Victor from 'victor'
 import { makeGetPreviewTrackVertices, getCachedSelector, makeGetPreviewVertices, getSliderColors, getVertexOffsets, getAllPreviewVertices } from '../machine/selectors'
-import { updateLayer, setSelectedLayer } from '../layers/layersSlice'
+import { updateLayer } from '../layers/layersSlice'
 import { getCurrentLayer, makeGetLayerIndex, getNumVisibleLayers } from '../layers/selectors'
 import { roundP } from '../../common/util'
 import { getSliderBounds } from '../../common/geometry'
@@ -208,7 +208,8 @@ const PreviewLayer = (ownProps) => {
   }
 
   function onSelect() {
-    dispatch(setSelectedLayer(props.selected == null ? props.currentLayer.id : null))
+    // deselection is currently disabled
+    // dispatch(setSelectedLayer(props.selected == null ? props.currentLayer.id : null))
   }
 
   const shapeRef = React.createRef()

--- a/src/features/preview/PreviewWindow.js
+++ b/src/features/preview/PreviewWindow.js
@@ -25,7 +25,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     layers: state.layers,
     currentLayer: getCurrentLayer(state),
-    selectedId: state.layers.selected,
     konvaIds: getKonvaLayerIds(state),
     use_rect: state.machine.rectangular,
     dragging: isDragging(state),
@@ -84,21 +83,14 @@ class PreviewWindow extends Component {
     const height = this.props.use_rect ? maxY - minY : radius * 2
     const visibilityClass = `preview-wrapper ${this.visible ? 'd-flex align-items-center' : 'd-none'}`
 
-    const checkDeselect = e => {
-      // deselect when clicked on empty area
-      if (e.target.className !== undefined && e.target.className !== 'Rect') {
-        this.props.onChange({selectedId: null})
-      }
-     }
-
-     // define Konva clip functions that will let us clip vertices not bound by
-     // machine limits when dragging, and produce a visually seamless experience.
-     const clipCircle = ctx => {
-       ctx.arc(0, 0, radius, 0, Math.PI * 2, false)
-     }
-     const clipRect = ctx => {
-       ctx.rect(-width/2, -height/2, width, height)
-     }
+    // define Konva clip functions that will let us clip vertices not bound by
+    // machine limits when dragging, and produce a visually seamless experience.
+    const clipCircle = ctx => {
+     ctx.arc(0, 0, radius, 0, Math.PI * 2, false)
+    }
+    const clipRect = ctx => {
+     ctx.rect(-width/2, -height/2, width, height)
+    }
 
     const scaleByWheel = (size, deltaY) => {
       const sign = Math.sign(deltaY)
@@ -123,8 +115,6 @@ class PreviewWindow extends Component {
             scaleY={scale * reduceScale}
             height={height * scale}
             width={width * scale}
-            onMouseDown={checkDeselect}
-            onTouchStart={checkDeselect}
             offsetX={-width/2*(1/reduceScale)}
             offsetY={-height/2*(1/reduceScale)}
             onWheel={e => {


### PR DESCRIPTION
If the machine preview has focus, you can use arrow keys to move the current layer around. Shift makes it more fine-grained. I tried allowing arrow keys to work even outside of the machine preview, but it was interfering with other controls making use of them (like scrollbars or option fields), so I reverted that behavior.

I also removed the logic to allow deselection of the current layer by clicking on it. I seem to recall us talking about doing that, anyway, and it makes the movement using keys more consistent (you can't accidentally deselect a layer when clicking on the preview).