### PR TITLE
Fix arrow key moving the layer when Downloader is focused

### DIFF
--- a/src/features/preview/MachinePreview.js
+++ b/src/features/preview/MachinePreview.js
@@ -61,13 +61,13 @@ class MachinePreview extends Component {
 
   render() {
     return (
-      <div className="machine-preview d-flex flex-grow-1 flex-column" id="machine-preview" ref={(el) => { this.el = el }} tabIndex={0} onKeyDown={e => {
-        if (this.props.currentLayerSelected) {
-          this.props.onKeyDown(e, this.props.currentLayer)
-        }
-      }}>
+      <div className="machine-preview d-flex flex-grow-1 flex-column" id="machine-preview">
         <div className="flex-grow-1 d-flex flex-column">
-          <div id="preview-wrapper" className="preview-wrapper d-flex flex-column align-items-center">
+          <div id="preview-wrapper" className="preview-wrapper d-flex flex-column align-items-center" ref={(el) => { this.el = el }} tabIndex={0} onKeyDown={e => {
+            if (this.props.currentLayerSelected) {
+              this.props.onKeyDown(e, this.props.currentLayer)
+            }
+          }}>
             <PreviewWindow />
           </div>
 


### PR DESCRIPTION
This prevent the arrow keyboard keys from updating the layer when editing the fields inside `<Downloader />`. To reproduce this bug, open the Downloader dialog, focus an input and press a keyboard direction key. The layer will be moved behind the dialog.