### PR TITLE
ensure that saved file imports can be reloaded

### DIFF
--- a/src/features/shapes/FileImport.js
+++ b/src/features/shapes/FileImport.js
@@ -24,6 +24,7 @@ export default class FileImport extends Shape {
       ...{
         vertices: [],
         maintainAspectRatio: true,
+        fileName: "",
       },
       ...(props === undefined
         ? {}

--- a/src/features/shapes/FileImport.js
+++ b/src/features/shapes/FileImport.js
@@ -35,6 +35,13 @@ export default class FileImport extends Shape {
   }
 
   initialDimensions(props) {
+    if (!props) { // undefined during import integrity checks
+      return {
+        width: 0,
+        height: 0
+      }
+    }
+
     const vertices = cloneVertices(props.vertices)
     const machine = getMachine(props.machine)
 

--- a/src/features/shapes/FileImport.js
+++ b/src/features/shapes/FileImport.js
@@ -35,10 +35,11 @@ export default class FileImport extends Shape {
   }
 
   initialDimensions(props) {
-    if (!props) { // undefined during import integrity checks
+    if (!props) {
+      // undefined during import integrity checks
       return {
         width: 0,
-        height: 0
+        height: 0,
       }
     }
 


### PR DESCRIPTION
Bug: Cannot reload a saved file import layer. It throws an exception. To reproduce, import an exported pattern as a layer and reload the page. The pattern gets reset. The same thing happens if you save to sdf and try to load the file.

This PR fixes the issue.