### PR TITLE
cap max segments

### DIFF
--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -295,6 +295,7 @@ export const subsample = (vertices, maxLength) => {
   let subsampledVertices = []
   let previous = undefined
   let next
+  const maxSegments = 1000
 
   for (next = 0; next < vertices.length; next++) {
     if (previous !== undefined) {
@@ -309,7 +310,13 @@ export const subsample = (vertices, maxLength) => {
         .multiply(Victor(maxLength, maxLength))
 
       // This loads up (start, end].
-      for (let step = 0; step < delta.magnitude() / maxLength; step++) {
+      const magnitude = delta.magnitude()
+
+      // If the magnitude is unreasonably large, cap the number of segments
+      // to prevent the creation of too many points
+      const segmentMaxLength = Math.max(magnitude / maxSegments, maxLength)
+
+      for (let step = 0; step < magnitude / segmentMaxLength; step++) {
         subsampledVertices.push(
           new Victor(
             start.x + step * deltaSegment.x,


### PR DESCRIPTION
Fixes #283.

In the 90 degree case, the wiper algorithm adds a point which is way outside of the bounds of the machine (e.g, x: 8000000000, y: 0). If an effect is added that calls subsample to break up long lines, this particular case results in an extremely high number of additional points being added, which overwhelms the browser.

I was unable to figure out how to modify this algorithm to sensibly clip the line. Instead, I modified subsample to cap the number of segments into which any given line can be divided. This seems to work well, and does not noticeably change the visible pattern. Please scrutinize.