### PR TITLE
optimize walking of L-path vertices

### DIFF
--- a/src/common/Graph.js
+++ b/src/common/Graph.js
@@ -16,10 +16,13 @@ export const mix = (v1, v2, s) => {
 export const buildGraph = (nodes) => {
   const graph = new Graph()
 
+  if (nodes.length > 0) {
+    graph.addNode(nodes[0])
+  }
+
   for (let i = 0; i < nodes.length - 1; i++) {
     const node1 = nodes[i]
     const node2 = nodes[i + 1]
-    graph.addNode(node1)
     graph.addNode(node2)
     graph.addEdge(node1, node2)
   }

--- a/src/common/Graph.js
+++ b/src/common/Graph.js
@@ -13,6 +13,27 @@ export const mix = (v1, v2, s) => {
   return new Victor(result[0], result[1])
 }
 
+export const buildGraph = (nodes) => {
+  const graph = new Graph()
+
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const node1 = nodes[i]
+    const node2 = nodes[i + 1]
+    graph.addNode(node1)
+    graph.addNode(node2)
+    graph.addEdge(node1, node2)
+  }
+
+  return graph
+}
+
+export const edgeKey = (node1, node2) => {
+  const node1Key = node1.toString()
+  const node2Key = node2.toString()
+
+  return [node1Key, node2Key].sort().toString()
+}
+
 // note: requires string-based nodes to work properly
 export default class Graph {
   constructor() {
@@ -42,13 +63,13 @@ export default class Graph {
   addEdge(node1, node2, weight = 1) {
     let node1Key = node1.toString()
     let node2Key = node2.toString()
-    let edgeKey = [node1Key, node2Key].sort().toString()
+    let edge12Key = edgeKey(node1, node2)
 
-    if (!this.edgeKeys.has(edgeKey)) {
+    if (!this.edgeKeys.has(edge12Key)) {
       this.adjacencyList[node1Key].push({ node: node2, weight })
       this.adjacencyList[node2Key].push({ node: node1, weight })
-      this.edgeKeys.add(edgeKey)
-      this.edgeMap[edgeKey] = [node1.toString(), node2.toString()]
+      this.edgeKeys.add(edge12Key)
+      this.edgeMap[edge12Key] = [node1.toString(), node2.toString()]
       this.clearCachedPaths()
     }
   }
@@ -60,6 +81,10 @@ export default class Graph {
 
   neighbors(node) {
     return this.adjacencyList[node.toString()].map((hash) => hash.node)
+  }
+
+  getNode(node) {
+    return this.nodeMap[node.toString()]
   }
 
   dijkstraShortestPath(startNode, endNode) {

--- a/src/features/export/Exporter.js
+++ b/src/features/export/Exporter.js
@@ -77,7 +77,7 @@ export default class Exporter {
       this.startComments()
       this.line("BEGIN PRE")
       this.endComments()
-      this.line(this.pre, this.pre !== "", false)
+      this.line(this.pre, this.pre !== "")
       this.startComments()
       this.line("END PRE")
       this.endComments()
@@ -91,7 +91,7 @@ export default class Exporter {
       this.startComments()
       this.line("BEGIN POST")
       this.endComments()
-      this.line(this.post, this.post !== "", false)
+      this.line(this.post, this.post !== "")
       this.startComments()
       this.line("END POST")
       this.endComments()
@@ -115,7 +115,7 @@ export default class Exporter {
     this.vertices = vertices
   }
 
-  line(content = "", add = true, sanitize = true) {
+  line(content = "", add = true) {
     if (add) {
       let padding = ""
       if (this.commenting) {
@@ -124,10 +124,7 @@ export default class Exporter {
           padding += "  "
         }
       }
-
-      const preparedContent = sanitize ? this.sanitizeValue(content) : content
-
-      this.lines.push(padding + preparedContent)
+      this.lines.push(padding + this.sanitizeValue(content))
     }
   }
 

--- a/src/features/export/Exporter.js
+++ b/src/features/export/Exporter.js
@@ -77,7 +77,7 @@ export default class Exporter {
       this.startComments()
       this.line("BEGIN PRE")
       this.endComments()
-      this.line(this.pre, this.pre !== "")
+      this.line(this.pre, this.pre !== "", false)
       this.startComments()
       this.line("END PRE")
       this.endComments()
@@ -91,7 +91,7 @@ export default class Exporter {
       this.startComments()
       this.line("BEGIN POST")
       this.endComments()
-      this.line(this.post, this.post !== "")
+      this.line(this.post, this.post !== "", false)
       this.startComments()
       this.line("END POST")
       this.endComments()
@@ -115,7 +115,7 @@ export default class Exporter {
     this.vertices = vertices
   }
 
-  line(content = "", add = true) {
+  line(content = "", add = true, sanitize = true) {
     if (add) {
       let padding = ""
       if (this.commenting) {
@@ -124,7 +124,10 @@ export default class Exporter {
           padding += "  "
         }
       }
-      this.lines.push(padding + this.sanitizeValue(content))
+
+      const preparedContent = sanitize ? this.sanitizeValue(content) : content
+
+      this.lines.push(padding + preparedContent)
     }
   }
 

--- a/src/features/shapes/lsystem/LSystem.js
+++ b/src/features/shapes/lsystem/LSystem.js
@@ -2,13 +2,13 @@ import Shape from "../Shape"
 import {
   lsystem,
   lsystemPath,
+  lsystemOptimize,
   onSubtypeChange,
   onMinIterations,
   onMaxIterations,
 } from "@/common/lindenmayer"
 import { subtypes } from "./subtypes"
-import { resizeVertices, cloneVertices } from "@/common/geometry"
-import { buildGraph, edgeKey } from "@/common/Graph"
+import { resizeVertices } from "@/common/geometry"
 
 const options = {
   subtype: {
@@ -64,65 +64,13 @@ export default class LSystem extends Shape {
       config.angle = Math.PI / 2
     }
 
-    const curve = lsystemPath(lsystem(config), config)
+    const path = lsystemOptimize(lsystemPath(lsystem(config), config), config)
     const scale = 18.0 // to normalize starting size
-    const path =
-      config.shortestPath >= iterations ? this.shortestPath(curve) : curve
 
     return resizeVertices(path, scale, scale)
   }
 
   getOptions() {
     return options
-  }
-
-  shortestPath(nodes) {
-    const graph = buildGraph(nodes)
-    const path = []
-    const visited = {}
-
-    for (let i = 0; i < nodes.length - 1; i++) {
-      const node1 = nodes[i]
-      const node2 = nodes[i + 1]
-      let node1Key = node1.toString()
-      let edge12Key = edgeKey(node1, node2)
-
-      if (visited[edge12Key]) {
-        const unvisitedNode = this.nearestUnvisitedNode(
-          i + 1,
-          nodes,
-          visited,
-          graph,
-        )
-
-        if (unvisitedNode != null) {
-          const shortestSubPath = graph.dijkstraShortestPath(
-            node1Key,
-            unvisitedNode.toString(),
-          )
-
-          path.push(...cloneVertices(shortestSubPath.slice(1)))
-          i = nodes.indexOf(unvisitedNode) - 1
-        }
-      } else {
-        path.push(node2)
-        visited[edge12Key] = true
-      }
-    }
-
-    return path
-  }
-
-  nearestUnvisitedNode(nodeIndex, nodes, visited, graph) {
-    for (let i = nodeIndex; i < nodes.length - 1; i++) {
-      const node1 = nodes[i]
-      const node2 = nodes[i + 1]
-
-      if (!visited[edgeKey(node1, node2)]) {
-        return node2
-      }
-    }
-
-    return null // all nodes visited
   }
 }

--- a/src/features/shapes/lsystem/LSystem.js
+++ b/src/features/shapes/lsystem/LSystem.js
@@ -7,7 +7,8 @@ import {
   onMaxIterations,
 } from "@/common/lindenmayer"
 import { subtypes } from "./subtypes"
-import { resizeVertices } from "@/common/geometry"
+import { resizeVertices, cloneVertices } from "@/common/geometry"
+import { buildGraph, edgeKey } from "@/common/Graph"
 
 const options = {
   subtype: {
@@ -63,13 +64,65 @@ export default class LSystem extends Shape {
       config.angle = Math.PI / 2
     }
 
-    let curve = lsystemPath(lsystem(config), config)
+    const curve = lsystemPath(lsystem(config), config)
     const scale = 18.0 // to normalize starting size
+    const path =
+      config.shortestPath >= iterations ? this.shortestPath(curve) : curve
 
-    return resizeVertices(curve, scale, scale)
+    return resizeVertices(path, scale, scale)
   }
 
   getOptions() {
     return options
+  }
+
+  shortestPath(nodes) {
+    const graph = buildGraph(nodes)
+    const path = []
+    const visited = {}
+
+    for (let i = 0; i < nodes.length - 1; i++) {
+      const node1 = nodes[i]
+      const node2 = nodes[i + 1]
+      let node1Key = node1.toString()
+      let edge12Key = edgeKey(node1, node2)
+
+      if (visited[edge12Key]) {
+        const unvisitedNode = this.nearestUnvisitedNode(
+          i + 1,
+          nodes,
+          visited,
+          graph,
+        )
+
+        if (unvisitedNode != null) {
+          const shortestSubPath = graph.dijkstraShortestPath(
+            node1Key,
+            unvisitedNode.toString(),
+          )
+
+          path.push(...cloneVertices(shortestSubPath.slice(1)))
+          i = nodes.indexOf(unvisitedNode) - 1
+        }
+      } else {
+        path.push(node2)
+        visited[edge12Key] = true
+      }
+    }
+
+    return path
+  }
+
+  nearestUnvisitedNode(nodeIndex, nodes, visited, graph) {
+    for (let i = nodeIndex; i < nodes.length - 1; i++) {
+      const node1 = nodes[i]
+      const node2 = nodes[i + 1]
+
+      if (!visited[edgeKey(node1, node2)]) {
+        return node2
+      }
+    }
+
+    return null // all nodes visited
   }
 }

--- a/src/features/shapes/lsystem/subtypes.js
+++ b/src/features/shapes/lsystem/subtypes.js
@@ -106,7 +106,8 @@ export const subtypes = {
     rules: {
       F: "FF-F-F-F-FF",
     },
-    maxIterations: 5,
+    maxIterations: 4,
+    shortestPath: 3,
   },
   // http://algorithmicbotany.org/papers/abop/abop-ch1.pdf
   "Koch Cube 2": {
@@ -115,7 +116,8 @@ export const subtypes = {
     rules: {
       F: "FF-F+F-F-FF",
     },
-    maxIterations: 5,
+    maxIterations: 4,
+    shortestPath: 3,
   },
   // https://onlinemathtools.com/l-system-generator
   "Koch Curve": {
@@ -136,6 +138,7 @@ export const subtypes = {
       F: "FF-F-F-F-F-F+F",
     },
     maxIterations: 4,
+    shortestPath: 3,
   },
   // http://mathforum.org/advanced/robertd/lsys2d.html
   "Koch Island": {
@@ -178,7 +181,8 @@ export const subtypes = {
       9: "--8++++6[+9++++7]--7",
     },
     angle: Math.PI / 5,
-    maxIterations: 6,
+    maxIterations: 5,
+    shortestPath: 5,
   },
   Plusses: {
     axiom: "XYXYXYX+XYXYXYX+XYXYXYX+XYXYXYX",

--- a/src/features/shapes/space_filler/SpaceFiller.js
+++ b/src/features/shapes/space_filler/SpaceFiller.js
@@ -2,6 +2,7 @@ import Shape from "../Shape"
 import {
   lsystem,
   lsystemPath,
+  lsystemOptimize,
   onSubtypeChange,
   onMinIterations,
   onMaxIterations,
@@ -86,7 +87,7 @@ export default class SpaceFiller extends Shape {
       config.angle = Math.PI / 2
     }
 
-    let curve = lsystemPath(lsystem(config), config)
+    let curve = lsystemOptimize(lsystemPath(lsystem(config), config), config)
     let scale = 1
 
     if (config.iterationsGrow) {

--- a/src/features/shapes/space_filler/subtypes.js
+++ b/src/features/shapes/space_filler/subtypes.js
@@ -58,7 +58,8 @@ export const subtypes = {
       9: "--8++++6[+9++++7]--7",
     },
     angle: Math.PI / 5,
-    maxIterations: 6,
+    maxIterations: 5,
+    shortestPath: 5,
     iterationsGrow: (config) => {
       return 1 + Math.max(1, 3 / config.iterations)
     },


### PR DESCRIPTION
Fixes #176.

Uses a modified shortest path algorithm to avoid re-walking edges that have already been walked. It does add computation time, so the subtype configuration enabled this optimization only if it helps the shape (reduces vertices) and doesn't bog down the browser.