### PR TITLE
annotated exports

### DIFF
--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -365,13 +365,6 @@ export const downsample = (vertices, tolerance = 0.0001) => {
   return result
 }
 
-// Normalize the theta value to the range [0, 2*pi)
-export const normalizeTheta = (theta) => {
-  const TWO_PI = Math.PI * 2
-
-  return ((theta % TWO_PI) + TWO_PI) % TWO_PI
-}
-
 // Convert x,y vertices to theta, rho vertices
 export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
   let vertices = []
@@ -396,7 +389,9 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
       subsampledVertices[next].x,
       subsampledVertices[next].y,
     )
-    rawTheta = normalizeTheta(rawTheta)
+
+    // Convert to [0, 2pi]
+    rawTheta = (rawTheta + 2.0 * Math.PI) % (2.0 * Math.PI)
 
     // Compute the difference to the last point.
     let deltaTheta = rawTheta - previousRawTheta
@@ -413,7 +408,7 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
 
     previousRawTheta = rawTheta
     previousTheta = theta
-    vertices.push(new Victor(normalizeTheta(theta), rho))
+    vertices.push(new Victor(theta, rho))
   }
 
   return vertices

--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -366,10 +366,14 @@ export const downsample = (vertices, tolerance = 0.0001) => {
 }
 
 // Convert x,y vertices to theta, rho vertices
-export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
+export const toThetaRho = (
+  subsampledVertices,
+  maxRadius,
+  rhoMax,
+  previousTheta = 0,
+  previousRawTheta = 0,
+) => {
   let vertices = []
-  let previousTheta = 0
-  let previousRawTheta = 0
 
   // Normalize the radius
   if (rhoMax < 0) {
@@ -408,7 +412,14 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
 
     previousRawTheta = rawTheta
     previousTheta = theta
-    vertices.push(new Victor(theta, rho))
+
+    const vertex = new Victor(theta, rho)
+
+    // small hack to preserve these values
+    vertex.theta = theta
+    vertex.rawTheta = rawTheta
+
+    vertices.push(vertex)
   }
 
   return vertices
@@ -463,7 +474,15 @@ export const toScaraGcode = (vertices, unitsPerCircle) => {
     const x = (unitsPerCircle * m1) / (2 * Math.PI)
     const y = (unitsPerCircle * m2) / (2 * Math.PI)
 
-    return new Victor(x, y)
+    // propagate theta if it exists
+    const vertex = new Victor(x, y)
+
+    if (thetaRho.theta) {
+      vertex.theta = thetaRho.theta
+      vertex.rawTheta = thetaRho.rawTheta
+    }
+
+    return vertex
   })
 }
 

--- a/src/common/geometry.js
+++ b/src/common/geometry.js
@@ -365,6 +365,13 @@ export const downsample = (vertices, tolerance = 0.0001) => {
   return result
 }
 
+// Normalize the theta value to the range [0, 2*pi)
+export const normalizeTheta = (theta) => {
+  const TWO_PI = Math.PI * 2
+
+  return ((theta % TWO_PI) + TWO_PI) % TWO_PI
+}
+
 // Convert x,y vertices to theta, rho vertices
 export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
   let vertices = []
@@ -389,8 +396,7 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
       subsampledVertices[next].x,
       subsampledVertices[next].y,
     )
-    // Convert to [0, 2pi]
-    rawTheta = (rawTheta + 2.0 * Math.PI) % (2.0 * Math.PI)
+    rawTheta = normalizeTheta(rawTheta)
 
     // Compute the difference to the last point.
     let deltaTheta = rawTheta - previousRawTheta
@@ -407,7 +413,7 @@ export const toThetaRho = (subsampledVertices, maxRadius, rhoMax) => {
 
     previousRawTheta = rawTheta
     previousTheta = theta
-    vertices.push(new Victor(theta, rho))
+    vertices.push(new Victor(normalizeTheta(theta), rho))
   }
 
   return vertices

--- a/src/features/effects/EffectEditor.js
+++ b/src/features/effects/EffectEditor.js
@@ -149,6 +149,9 @@ const EffectEditor = ({ id }) => {
           </Col>
         </Row>
       )}
+      {model.description && (
+        <div className="mt-3 mb-2 bg-light p-4">{model.description}</div>
+      )}
     </div>
   )
 }

--- a/src/features/effects/ProgramCode.js
+++ b/src/features/effects/ProgramCode.js
@@ -1,0 +1,51 @@
+import Effect from "./Effect"
+
+const options = {
+  programCodePre: {
+    title: "Start code",
+    type: "textarea",
+  },
+  programCodePost: {
+    title: "End code",
+    type: "textarea",
+  },
+}
+
+export default class ProgramCode extends Effect {
+  constructor() {
+    super("programCode")
+    this.label = "Program code"
+    this.description =
+      "When exporting the pattern to a file, the provided program code is added before and/or after this layer is rendered."
+  }
+
+  canChangeSize(state) {
+    return false
+  }
+
+  canRotate(state) {
+    return false
+  }
+
+  canMove(state) {
+    return false
+  }
+
+  getInitialState() {
+    return {
+      ...super.getInitialState(),
+      ...{
+        programCodePre: "",
+        programCodePost: "",
+      },
+    }
+  }
+
+  getVertices(effect, layer, vertices) {
+    return vertices
+  }
+
+  getOptions() {
+    return options
+  }
+}

--- a/src/features/effects/effectFactory.js
+++ b/src/features/effects/effectFactory.js
@@ -3,6 +3,7 @@ import Fisheye from "./Fisheye"
 import Loop from "./Loop"
 import Mask from "./Mask"
 import Noise from "./noise/Noise"
+import ProgramCode from "./ProgramCode"
 import Track from "./Track"
 import Transformer from "./Transformer"
 import Warp from "./Warp"
@@ -13,6 +14,7 @@ export const effectFactory = {
   fisheye: Fisheye,
   fineTuning: FineTuning,
   mask: Mask,
+  programCode: ProgramCode,
   noise: Noise,
   track: Track,
   warp: Warp,

--- a/src/features/export/ExportDownloader.js
+++ b/src/features/export/ExportDownloader.js
@@ -8,7 +8,7 @@ import { downloadFile } from "@/common/util"
 import DropdownOption from "@/components/DropdownOption"
 import InputOption from "@/components/InputOption"
 import CheckboxOption from "@/components/CheckboxOption"
-import { selectConnectedVertices } from "@/features/layers/layersSlice"
+import { selectLayersForExport } from "@/features/layers/layersSlice"
 import {
   selectExporterState,
   updateExporter,
@@ -57,7 +57,7 @@ const ExportDownloader = ({ showModal, toggleModal }) => {
               Math.pow(machine.maxY - machine.minY, 2.0),
           )
         : machine.maxRadius,
-    vertices: useSelector(selectConnectedVertices),
+    layers: useSelector(selectLayersForExport),
   }
   const exporter = new exporters[fileType](props)
 

--- a/src/features/export/Exporter.js
+++ b/src/features/export/Exporter.js
@@ -116,8 +116,8 @@ export default class Exporter {
       layers = layers.reverse()
     }
 
-    layers.forEach((layer) => {
-      let vertices = this.transformVertices(layer.vertices)
+    layers.forEach((layer, index) => {
+      let vertices = this.transformVertices(layer.vertices, index, layers)
 
       if (this.props.reverse) vertices = vertices.reverse()
       layer.vertices = vertices

--- a/src/features/export/Exporter.js
+++ b/src/features/export/Exporter.js
@@ -30,15 +30,15 @@ export const exporterOptions = {
     title: "Units per circle",
     type: "number",
   },
-  post: {
-    title: "Program end code",
+  pre: {
+    title: "Program start code",
     type: "textarea",
     isVisible: (exporter, state) => {
       return state.fileType !== SVG
     },
   },
-  pre: {
-    title: "Program start code",
+  post: {
+    title: "Program end code",
     type: "textarea",
     isVisible: (exporter, state) => {
       return state.fileType !== SVG
@@ -52,70 +52,139 @@ export const exporterOptions = {
 export default class Exporter {
   constructor(props) {
     this.props = props
+    this.pre = props.pre
+    this.post = props.post
     this.lines = []
     this.indentLevel = 0
+    this.digits = 3
   }
 
   export() {
-    this.pre = this.props.pre
-    this.post = this.props.post
-    let vertices = this.props.vertices
+    this.layers = this.prepareLayers(this.props.layers)
 
-    if (this.props.reverse) {
-      vertices = vertices.reverse()
-    }
-    this.computeOutputVertices(vertices)
+    const allVertices = this.layers.map((layer) => layer.vertices).flat()
+    this.computeStats(allVertices, [this])
+
     this.header()
-    this.startComments()
-    this.line()
-    this.keyValueLine("File name", "'" + this.props.fileName + "'")
-    this.keyValueLine("File type", this.props.fileType)
-    this.line()
-    this.endComments()
+    this.comment(() => {
+      this.line()
+      this.keyValueLine("File name", "'" + this.props.fileName + "'")
+      this.keyValueLine("File type", this.props.fileType)
+      this.line()
+    })
 
     if (this.pre !== "") {
-      this.startComments()
-      this.line("BEGIN PRE")
-      this.endComments()
-      this.line(this.pre, this.pre !== "")
-      this.startComments()
-      this.line("END PRE")
-      this.endComments()
+      this.comment("BEGIN PRE")
+      this.line(this.pre, this.pre !== "", false)
+      this.comment("END PRE")
     }
 
-    this.line()
-    this.exportCode(this.vertices)
+    this.exportCode()
     this.line()
 
     if (this.post !== "") {
-      this.startComments()
-      this.line("BEGIN POST")
-      this.endComments()
-      this.line(this.post, this.post !== "")
-      this.startComments()
-      this.line("END POST")
-      this.endComments()
+      this.comment("BEGIN POST")
+      this.line(this.post, this.post !== "", false)
+      this.comment("END POST")
     }
+
     this.footer()
     this.line()
 
     return this.lines
   }
 
-  header() {
-    // default does nothing
+  // computes stats from vertices and replaces the corresponding stat variables within pre and
+  // post blocks
+  computeStats(vertices, objects) {
+    const values = this.collectStats(vertices)
+
+    Object.keys(values).forEach((variable) => {
+      objects.forEach((obj) => {
+        obj.pre = this.replaceVariable(obj.pre, variable, values[variable])
+        obj.post = this.replaceVariable(obj.post, variable, values[variable])
+      })
+    })
   }
 
-  footer() {
-    // default does nothing
+  // given layers and connectors with vertices, transforms those vertices into an exportable format
+  prepareLayers(layers) {
+    layers = [...layers]
+
+    // reverse both the order of the layers and the vertices within them
+    if (this.props.reverse) {
+      layers = layers.reverse()
+    }
+
+    layers.forEach((layer) => {
+      let vertices = this.transformVertices(layer.vertices)
+
+      if (this.props.reverse) vertices = vertices.reverse()
+      layer.vertices = vertices
+    })
+
+    return layers
   }
 
-  computeOutputVertices(vertices) {
-    // default does nothing
-    this.vertices = vertices
+  exportCode() {
+    this.layers.forEach((layer) => {
+      const hasCode = layer.code && layer.code.length > 0
+
+      if (hasCode) {
+        this.computeStats(layer.vertices, layer.code)
+
+        this.line("")
+        this.actionComment(layer, "BEGIN PRE")
+
+        layer.code.forEach((block) => {
+          this.line(block.pre, block.pre !== "", false)
+        })
+        this.actionComment(layer, "END PRE")
+      }
+
+      this.line("")
+      this.actionComment(layer, "BEGIN")
+
+      layer.vertices.forEach((vertex) => {
+        this.line(this.code(vertex))
+      })
+
+      this.actionComment(layer, "END")
+
+      if (hasCode) {
+        this.line("")
+        this.actionComment(layer, "BEGIN POST")
+
+        layer.code.forEach((block) => {
+          this.line(block.post, block.post !== "", false)
+        })
+        this.actionComment(layer, "END POST")
+      }
+    })
   }
 
-  line(content = "", add = true) {
+  // override to transform vertices for export
+  transformVertices(vertices) {
+    return vertices
+  }
+
+  // override to collect stats for use in PRE and POST blocks
+  collectStats() {
+    return {}
+  }
+
+  // override to export a header
+  header() {}
+
+  // override to export a footer
+  footer() {}
+
+  // override to provide code for a given vertex
+  code(vertex) {
+    throw "Override this method"
+  }
+
+  line(content = "", add = true, sanitize = true) {
     if (add) {
       let padding = ""
       if (this.commenting) {
@@ -124,7 +193,10 @@ export default class Exporter {
           padding += "  "
         }
       }
-      this.lines.push(padding + this.sanitizeValue(content))
+
+      const preparedContent = sanitize ? this.sanitizeValue(content) : content
+
+      this.lines.push(padding + preparedContent)
     }
   }
 
@@ -146,6 +218,23 @@ export default class Exporter {
 
   endComments() {
     this.commenting = false
+  }
+
+  comment(fn) {
+    this.startComments()
+    typeof fn === "function" ? fn() : this.line(fn)
+    this.endComments()
+  }
+
+  actionComment(layer, action) {
+    const name = layer.name ? ` ${layer.name}` : ""
+    this.comment(`${action} ${layer.type}: ${layer.index}${name}`)
+  }
+
+  replaceVariable(str, variable, value) {
+    const regex = new RegExp(`{${variable}}`, "gi")
+
+    return str.replace(regex, value.toFixed(this.digits))
   }
 
   sanitizeValue(value) {

--- a/src/features/export/ScaraGCodeExporter.js
+++ b/src/features/export/ScaraGCodeExporter.js
@@ -8,20 +8,6 @@ export default class ScaraGCodeExporter extends GCodeExporter {
     this.offsetY = 0
   }
 
-  // collects stats for use in PRE and POST blocks
-  collectStats(vertices) {
-    return {
-      mintheta: Math.min(...vertices.map((v) => v.x)),
-      minrho: Math.min(...vertices.map((v) => v.y)),
-      maxtheta: Math.max(...vertices.map((v) => v.x)),
-      maxrho: Math.max(...vertices.map((v) => v.y)),
-      starttheta: vertices[0].x,
-      startrho: vertices[0].y,
-      endtheta: vertices[vertices.length - 1].x,
-      endrho: vertices[vertices.length - 1].y,
-    }
-  }
-
   // transforms vertices into a SCARA GCode format
   transformVertices(vertices) {
     vertices = toScaraGcode(

--- a/src/features/export/ScaraGCodeExporter.js
+++ b/src/features/export/ScaraGCodeExporter.js
@@ -8,8 +8,22 @@ export default class ScaraGCodeExporter extends GCodeExporter {
     this.offsetY = 0
   }
 
-  computeOutputVertices(vertices) {
-    //  downsample larger lines into smaller ones, then convert to theta-rho
+  // collects stats for use in PRE and POST blocks
+  collectStats(vertices) {
+    return {
+      mintheta: Math.min(...vertices.map((v) => v.x)),
+      minrho: Math.min(...vertices.map((v) => v.y)),
+      maxtheta: Math.max(...vertices.map((v) => v.x)),
+      maxrho: Math.max(...vertices.map((v) => v.y)),
+      starttheta: vertices[0].x,
+      startrho: vertices[0].y,
+      endtheta: vertices[vertices.length - 1].x,
+      endrho: vertices[vertices.length - 1].y,
+    }
+  }
+
+  // transforms vertices into a SCARA GCode format
+  transformVertices(vertices) {
     vertices = toScaraGcode(
       toThetaRho(
         subsample(vertices, 2.0),
@@ -18,6 +32,7 @@ export default class ScaraGCodeExporter extends GCodeExporter {
       ),
       parseFloat(this.props.unitsPerCircle),
     )
-    return super.computeOutputVertices(vertices)
+
+    return super.transformVertices(vertices)
   }
 }

--- a/src/features/export/ScaraGCodeExporter.js
+++ b/src/features/export/ScaraGCodeExporter.js
@@ -9,16 +9,31 @@ export default class ScaraGCodeExporter extends GCodeExporter {
   }
 
   // transforms vertices into a SCARA GCode format
-  transformVertices(vertices) {
+  transformVertices(vertices, index, layers) {
+    let theta, rawTheta
+
+    if (index == 0) {
+      theta = 0
+      rawTheta = 0
+    } else {
+      // preserve previous theta value
+      const prevVertices = layers[index - 1].vertices
+      const last = prevVertices[prevVertices.length - 1]
+      theta = last.theta
+      rawTheta = last.rawTheta // already transformed
+    }
+
     vertices = toScaraGcode(
       toThetaRho(
         subsample(vertices, 2.0),
         this.props.maxRadius,
         parseFloat(this.props.polarRhoMax),
+        theta,
+        rawTheta,
       ),
       parseFloat(this.props.unitsPerCircle),
     )
 
-    return super.transformVertices(vertices)
+    return super.transformVertices(vertices, index, layers)
   }
 }

--- a/src/features/export/ThetaRhoExporter.js
+++ b/src/features/export/ThetaRhoExporter.js
@@ -1,68 +1,47 @@
 import Exporter from "./Exporter"
 import { subsample, toThetaRho } from "@/common/geometry"
 
-function thetarho(vertex) {
-  return "" + vertex.x.toFixed(5) + " " + vertex.y.toFixed(5)
-}
-
 export default class ThetaRhoExporter extends Exporter {
   constructor(props) {
     super(props)
     this.fileExtension = ".thr"
     this.label = "ThetaRho"
     this.commentChar = "#"
+    this.digits = 5
   }
 
-  // computes vertices compatible with the theta rho format, and replaces
-  // placeholder variables in pre/post blocks.
-  computeOutputVertices(vertices) {
-    // First, downsample larger lines into smaller ones.
+  // collects stats for use in PRE and POST blocks
+  collectStats(vertices) {
+    return {
+      mintheta: Math.min(...vertices.map((v) => v.x)),
+      minrho: Math.min(...vertices.map((v) => v.y)),
+      maxtheta: Math.max(...vertices.map((v) => v.x)),
+      maxrho: Math.max(...vertices.map((v) => v.y)),
+      starttheta: vertices[0].x,
+      startrho: vertices[0].y,
+      endtheta: vertices[vertices.length - 1].x,
+      endrho: vertices[vertices.length - 1].y,
+    }
+  }
+
+  // transforms vertices into a theta-rho format
+  transformVertices(vertices) {
+    // downsample larger lines into smaller ones
     const maxLength = 2.0
     const subsampledVertices = subsample(vertices, maxLength)
 
-    // Convert to theta, rho
-    this.vertices = toThetaRho(
+    // convert to theta, rho
+    return toThetaRho(
       subsampledVertices,
       this.props.maxRadius,
       parseFloat(this.props.polarRhoMax),
     )
-
-    let starttheta = this.vertices[0].x
-    let startrho = this.vertices[0].y
-    let endtheta = this.vertices[this.vertices.length - 1].x
-    let endrho = this.vertices[this.vertices.length - 1].y
-    let mintheta = 1e9
-    let minrho = 1e9
-    let maxtheta = -1e9
-    let maxrho = -1e9
-
-    this.vertices.forEach((thetarho) => {
-      minrho = Math.min(thetarho.y, minrho)
-      maxrho = Math.max(thetarho.y, maxrho)
-      mintheta = Math.min(thetarho.x, mintheta)
-      maxtheta = Math.max(thetarho.x, maxtheta)
-    })
-
-    // Replace pre/post placeholder variables
-    this.pre = this.pre.replace(/{starttheta}/gi, starttheta.toFixed(3))
-    this.pre = this.pre.replace(/{startrho}/gi, startrho.toFixed(3))
-    this.pre = this.pre.replace(/{endtheta}/gi, endtheta.toFixed(3))
-    this.pre = this.pre.replace(/{endrho}/gi, endrho.toFixed(3))
-    this.pre = this.pre.replace(/{mintheta}/gi, mintheta.toFixed(3))
-    this.pre = this.pre.replace(/{minrho}/gi, minrho.toFixed(3))
-    this.pre = this.pre.replace(/{maxtheta}/gi, maxtheta.toFixed(3))
-    this.pre = this.pre.replace(/{maxrho}/gi, maxrho.toFixed(3))
-    this.post = this.post.replace(/{starttheta}/gi, starttheta.toFixed(3))
-    this.post = this.post.replace(/{startrho}/gi, startrho.toFixed(3))
-    this.post = this.post.replace(/{endtheta}/gi, endtheta.toFixed(3))
-    this.post = this.post.replace(/{endrho}/gi, endrho.toFixed(3))
-    this.post = this.post.replace(/{mintheta}/gi, mintheta.toFixed(3))
-    this.post = this.post.replace(/{minrho}/gi, minrho.toFixed(3))
-    this.post = this.post.replace(/{maxtheta}/gi, maxtheta.toFixed(3))
-    this.post = this.post.replace(/{maxrho}/gi, maxrho.toFixed(3))
   }
 
-  exportCode(vertices) {
-    vertices.map(thetarho).forEach((line) => this.line(line))
+  // provides a theta-rho machine instruction for a given vertex
+  code(vertex) {
+    return (
+      "" + vertex.x.toFixed(this.digits) + " " + vertex.y.toFixed(this.digits)
+    )
   }
 }

--- a/src/features/export/ThetaRhoExporter.js
+++ b/src/features/export/ThetaRhoExporter.js
@@ -25,16 +25,31 @@ export default class ThetaRhoExporter extends Exporter {
   }
 
   // transforms vertices into a theta-rho format
-  transformVertices(vertices) {
+  transformVertices(vertices, index, layers) {
     // downsample larger lines into smaller ones
     const maxLength = 2.0
     const subsampledVertices = subsample(vertices, maxLength)
+
+    let theta, rawTheta
+
+    if (index == 0) {
+      theta = 0
+      rawTheta = 0
+    } else {
+      // preserve previous theta value
+      const prevVertices = layers[index - 1].vertices
+      const last = prevVertices[prevVertices.length - 1]
+      theta = last.theta
+      rawTheta = last.rawTheta // already transformed
+    }
 
     // convert to theta, rho
     return toThetaRho(
       subsampledVertices,
       this.props.maxRadius,
       parseFloat(this.props.polarRhoMax),
+      theta,
+      rawTheta,
     )
   }
 

--- a/src/features/layers/layersSlice.js
+++ b/src/features/layers/layersSlice.js
@@ -365,9 +365,10 @@ const selectMachineVertices = createCachedSelector(
   (state, id) => id,
   selectLayerVertices,
   selectLayerIndex,
+  selectLayerById,
   selectNumVisibleLayers,
   selectCurrentMachine,
-  (id, vertices, layerIndex, numLayers, machine) => {
+  (id, vertices, layerIndex, layer, numLayers, machine) => {
     if (!machine) {
       return [] // zombie child
     }
@@ -378,9 +379,8 @@ const selectMachineVertices = createCachedSelector(
         start: layerIndex === 0,
         end: layerIndex === numLayers - 1,
       }
-      const machineModel = getMachine(machine)
 
-      return machineModel.polish(vertices, layerInfo)
+      return getMachine(machine).polish(vertices, layerInfo)
     } else {
       return []
     }
@@ -542,13 +542,60 @@ export const selectConnectedVertices = createSelector(selectState, (state) => {
   log("selectConnectedVertices")
   const visibleLayerIds = selectVisibleLayerIds(state)
 
-  return visibleLayerIds
-    .map((id, idx) => {
-      const vertices = selectMachineVertices(state, id)
-      const connector = selectConnectingVertices(state, id)
-      return [...vertices, ...connector]
+  return visibleLayerIds.reduce((acc, id) => {
+    const vertices = selectMachineVertices(state, id)
+    const connector = selectConnectingVertices(state, id)
+
+    acc.push(...vertices, ...connector.slice(1, -1))
+
+    return acc
+  }, [])
+})
+
+// returns an array of layers (and connectors) in an object structure designed to be exported by
+// an exporter
+export const selectLayersForExport = createSelector(selectState, (state) => {
+  if (!state.fonts.loaded) {
+    return []
+  } // wait for fonts
+
+  log("selectLayersForExport")
+  const visibleLayerIds = selectVisibleLayerIds(state)
+  let connectorCnt = 0
+
+  return visibleLayerIds.reduce((acc, id, index) => {
+    const vertices = selectMachineVertices(state, id)
+    const connector = selectConnectingVertices(state, id)
+    const effects = selectEffectsByLayerId(state, id)
+    const info = selectLayerById(state, id)
+    const codeEffects = effects.filter(
+      (effect) => effect.type === "programCode",
+    )
+
+    acc.push({
+      name: info.name,
+      type: "LAYER",
+      index,
+      vertices,
+      code: codeEffects.map((effect) => {
+        return {
+          pre: effect.programCodePre,
+          post: effect.programCodePost,
+        }
+      }),
     })
-    .flat()
+
+    if (connector.length > 0) {
+      acc.push({
+        type: "CONNECTOR",
+        index: connectorCnt,
+        vertices: connector,
+      })
+      connectorCnt += 1
+    }
+
+    return acc
+  }, [])
 })
 
 // returns an array of vertices connecting a given layer to the next (if it exists)


### PR DESCRIPTION
This PR addresses the following issues:

#256 Starting GCode getting reformatted
#237 Add new "code" layer
#236 Add Comment Line Between Tracks on Export
#216 Layer changes in the pattern files

New features:

1. The start and end of each layer and connector is noted in exports as comments.
2. New "program code" effect which adds ability to insert PRE/POST code logic around layers. Variable substitution is also supported in these blocks, local to the given layer (e.g., maxx, maxy).

To test the export format changes, export a pattern in different formats (and ideally compare with older exports).
To test the new effect, add one to a shape and add some sample GCODE or instructions before you export.

This PR introduces a likely bug (or at least a difference) in the SCARA output. If you do a before/after PR export, you'll see the x/y value differences. This occurs because I've added logic to normalize theta during export between 0 and 2PI. It works fine with .thr files, as the exported theta values are equivalent. @jeffeb3 can you let me know if the changes here to the SCARA outputs are broken? We can certainly rollback the normalization, but I think it's generally a good idea.