### PR TITLE
fix maxRadius calculation

### DIFF
--- a/src/features/export/ExportDownloader.js
+++ b/src/features/export/ExportDownloader.js
@@ -53,8 +53,8 @@ const ExportDownloader = ({ showModal, toggleModal }) => {
     maxRadius:
       machine.type === "rectangular"
         ? Math.sqrt(
-            Math.pow((machine.maxX - machine.minX)/2, 2.0) +
-              Math.pow((machine.maxY - machine.minY)/2, 2.0),
+            Math.pow((machine.maxX - machine.minX) / 2, 2.0) +
+              Math.pow((machine.maxY - machine.minY) / 2, 2.0),
           )
         : machine.maxRadius,
     vertices: useSelector(selectConnectedVertices),

--- a/src/features/export/ExportDownloader.js
+++ b/src/features/export/ExportDownloader.js
@@ -53,8 +53,8 @@ const ExportDownloader = ({ showModal, toggleModal }) => {
     maxRadius:
       machine.type === "rectangular"
         ? Math.sqrt(
-            Math.pow(machine.maxX - machine.minX, 2.0) +
-              Math.pow(machine.maxY - machine.minY, 2.0),
+            Math.pow((machine.maxX - machine.minX)/2, 2.0) +
+              Math.pow((machine.maxY - machine.minY)/2, 2.0),
           )
         : machine.maxRadius,
     vertices: useSelector(selectConnectedVertices),


### PR DESCRIPTION
Fixes #222 and #285.

I believe this is as easy as correctly calculating the maxRadius when exporting to a rectangular table. We were calculating a radius double the actual maximum. This bumps the max rho to 1 in the exported file.