### PR TITLE
Fix Docker build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for development of sandify
 
-FROM node:20.6.1
+FROM node:20.18.1
 
 RUN npm install -g npm
 #RUN npm install -g


### PR DESCRIPTION
fix issue:
```
Status: Downloaded newer image for node:20.6.1
 ---> af422ffafa37
Step 2/6 : RUN npm install -g npm
 ---> Running in 94e4db490d0e
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm ERR! notsup Actual:   {"npm":"9.8.1","node":"v20.6.1"}

npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-12-29T19_02_51_395Z-debug-0.log
ERROR: Service 'sandify' failed to build: The command '/bin/sh -c npm install -g npm' returned a non-zero code: 1
```